### PR TITLE
Update timezone_names.json

### DIFF
--- a/timezonefinder/timezone_names.json
+++ b/timezonefinder/timezone_names.json
@@ -333,7 +333,7 @@
   "Europe/Istanbul",
   "Europe/Jersey",
   "Europe/Kaliningrad",
-  "Europe/Kyiv",
+  "Europe/Kiev",
   "Europe/Kirov",
   "Europe/Lisbon",
   "Europe/Ljubljana",


### PR DESCRIPTION
`pg_timezone_names` and Python `pytz` get "Kiev" not "Kyiv".