### PR TITLE
Correct tzfpy docs

### DIFF
--- a/docs/3_about.rst
+++ b/docs/3_about.rst
@@ -74,11 +74,11 @@ Comparison to tzfpy
 
 - ``tzfpy`` is a Python binding of the Rust package ``tzf-rs``
 - ``tzfpy`` has no startup time
-- ``tzfpy`` uses a hierarchical tree of rectangles as timezone polygons (data):
+- ``tzfpy`` uses simplified timezone polygons (data):
     - this reduces the memory requirements
     - this reduces the accuracy
     - this increases the lookup speed
-
+- ``tzfpy`` uses hierarchical tree of rectangles to speed up the lookup but auto fall back to polygon data if cache miss
 
 Comparison to pytzwhere
 -----------------------


### PR DESCRIPTION
It's true that tzfpy is not so accurate around bounders(about 3km ranges). But it is because of using simplified polygons.

tzfpy uses rectangles as index to speed up but auto fall back to polygon data if cache is missed. It's written in Rust here: https://github.com/ringsaturn/tzf-rs/blob/v0.4.1/src/lib.rs#L307-L318