### PR TITLE
Update pypa/cibuildwheel action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         run: pip install poetry
 
       - name: "Build wheels"
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.20.0
         with:
           output-dir: dist
         env:


### PR DESCRIPTION
Fixes installing package for centos found in #237