### PR TITLE
Use poetry-core 1.x to avoid cibuildwheel failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ numba = ["numba"]
 pytz = ["pytz"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "cffi", "setuptools>=65.5"]
+requires = ["poetry-core>=1.0.0,<2.0.0", "cffi", "setuptools>=65.5"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.build]


### PR DESCRIPTION
Somehow build fails with poetry-core 2.0. Pinning version to 1.x. I will investigate the Poetry compatibility problem later.

Local reproduction:
```sh
CIBW_PLATFORM=linux CIBW_MANYLINUX_X86_64_IMAGE=manylinux2014 CIBW_MUSLLINUX_X86_64_IMAGE=musllinux_1_1 CIBW_BUILD="cp312-*" CIBW_BUILD_FRONTEND=pip CIBW_BEFORE_ALL_LINUX_MANYLINUX2014="yum install -y libffi-devel clang make" CIBW_BEFORE_ALL_LINUX_MUSLLINUX_1_1="apk add --no-cache libffi-dev clang make" CIBW_ARCHS=native CIBW_BUILD_VERBOSITY=1 cibuildwheel
```

Fixes  #267