### PR TITLE
Attach artifacts to GH release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,6 +206,7 @@ jobs:
           draft: false
           prerelease: false
           skipIfReleaseExists: true
+          artifacts: "dist/timezonefinder*.whl,dist/timezonefinder*.tar.gz"
 
   publish-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
As in #321, let's attach wheels and sdist to GitHub release in case they are removed from PyPI due to lack of space