### PR TITLE
Build one universal abi3 wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
 
 env:
-  # the supported Python versions for pre-built wheels
-  CIBW_BUILD_VERSIONS: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+  # Use one base Python version with future-proof abi3 support
+  CIBW_BUILD_VERSIONS: "cp39-*"
 
 jobs:
   pre-commit-hooks:
@@ -91,6 +91,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX_MANYLINUX2014: yum install -y libffi-devel clang make
           CIBW_BEFORE_ALL_LINUX_MUSLLINUX_1_1: apk add --no-cache libffi-dev clang make
           CIBW_BUILD_VERBOSITY: 1
+          BUILD_ABI3: true
 
       - name: "Upload wheel as artifact"
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,21 @@ markers = [
     "unit: mark test as a unit test",
     "integration: mark test as an integration test"
 ]
+
+# Use abi3audit to check wheel abi3 conformance
+# A first line in command is a default value
+[tool.cibuildwheel.linux]
+repair-wheel-command = [
+  "auditwheel repair -w {dest_dir} {wheel}",
+  "uvx abi3audit --strict --summary {wheel}",
+]
+[tool.cibuildwheel.macos]
+repair-wheel-command = [
+  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
+  "uvx abi3audit --strict --summary {wheel}",
+]
+[tool.cibuildwheel.windows]
+repair-wheel-command = [
+  "copy {wheel} {dest_dir}",
+  "uvx abi3audit --strict --summary {wheel}",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,12 @@
 from setuptools import setup
+import os
 
-setup(cffi_modules=["timezonefinder/build.py:ffibuilder"])
+# Check whether to indicate abi3 support in a wheel name
+# CFFI and setuptools use their own rules to determine ABI3 support
+_abi3 = bool(os.getenv("BUILD_ABI3", ""))
+print("Using ABI3 wheel suffix:", _abi3)
+
+setup(
+    cffi_modules=["timezonefinder/build.py:ffibuilder"],
+    options={"bdist_wheel": {"py_limited_api": "cp39"} if _abi3 else {}},
+)


### PR DESCRIPTION
It's possible to avoid a combinatory explosion with Python version by using abi3 (aka [Python limited API](https://docs.python.org/3/c-api/stable.html#stable-abi). It allows the use of a single Python 3.9 base and building future-proof wheels.

To enable the ABI3 support, we should
1. Build binaries with `Py_LIMITED_API` flag enabled. It is [done automatically via cffi](https://cffi.readthedocs.io/en/latest/cdef.html#ffibuilder-compile-etc-compiling-out-of-line-modules) for a few supported platforms. 
2. announce support by having abi3 wheel suffix (`timezonefinder-8.0.0-cp39-abi3-macosx_10_9_x86_64.whl`). It is done via `bdist` and is not related to the support within a binary. That's why we cannot blindly enable it, but pass an env variable from our CI build pipeline, because we are sure we're building a supported configuration (CPython without free-threading)
3. Run [`abi3audit`](https://github.com/pypa/abi3audit) in addition to `audithweel`. In case the step (2) is wrong, it will be [flagged immediately](https://blog.trailofbits.com/2022/11/15/python-wheels-abi-abi3audit/).
4. We still build for musl / manylinux

References #321