### PR TITLE
Optimize shortcut compilation performance

### DIFF
--- a/scripts/hex_utils.py
+++ b/scripts/hex_utils.py
@@ -157,10 +157,18 @@ class Hex:
 
     @property
     def poly_candidates(self) -> Set[int]:
-        self._init_candidates()
-        real_candidates = set(filter(self.is_poly_candidate, self._poly_candidates))
-        self._poly_candidates = real_candidates
-        return self._poly_candidates
+        candidates = self._poly_candidates
+        if candidates is None:
+            self._init_candidates()
+            candidates = self._poly_candidates
+            if candidates is None:
+                return set()
+            filtered_candidates = {
+                poly_id for poly_id in candidates if self.is_poly_candidate(poly_id)
+            }
+            self._poly_candidates = filtered_candidates
+            candidates = filtered_candidates
+        return candidates
 
     def lies_in_cell(self, poly_nr: int) -> bool:
         hex_coords = self.coords


### PR DESCRIPTION
## Summary
- restructure shortcut ordering to group polygons by zone and pre-sort them with less Python overhead
- throttle shortcut compilation progress output to avoid per-hex flush overhead during long runs
- cache filtered polygon candidates in Hex objects so boundary filtering is performed only once per cell

## Testing
- `uv run pytest -m "not integration"` *(fails: optional `pytz` dependency unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ed353c9c8321837ed501e5b2bd9e