### PR TITLE
Add package extras for numba, pytz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,16 @@ proto = [
     "tabulate>=0.9.0",
 ]
 
+# Package extras
+[project.optional-dependencies]
+numba = [
+  "numba>=0.56,<1; python_version < '3.12'",
+  "numba>=0.59,<1; python_version >= '3.12'",
+]
+pytz = [
+    "pytz>=2022.7.1"
+]
+
 [build-system]
 requires = ["setuptools>=61", "cffi"]
 # Use setuptools build backend to build CFFI extensions via setup.py


### PR DESCRIPTION
Since migration to `uv` and `pyproject`, numba and pytz were not package extras, so `pip install timezonefinder[numba]` would silently skip the numba installation

Relates to #359