### PR TITLE
Avoid an exception on termination in __del__ 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+8.1.1 (???)
+-----------
+
+* Bug fixed where on termination we may hit an exception attempting to close resources in ``FileCoordAccessor``.
+
+
 
 8.1.0 (2025-09-22)
 ------------------

--- a/timezonefinder/coord_accessors.py
+++ b/timezonefinder/coord_accessors.py
@@ -101,8 +101,11 @@ class FileCoordAccessor(AbstractCoordAccessor):
 
     def cleanup(self) -> None:
         """Clean up resources."""
-        utils.close_resource(self.coord_file)
-        utils.close_resource(self.coord_buf)
+        # At termination utils may have been tidied up. If we're terminating we don't need to
+        # worry about closing file handles so just avoid an exception.
+        if getattr(utils, "close_resource", None) is not None:
+            utils.close_resource(self.coord_file)
+            utils.close_resource(self.coord_buf)
         del self.polygon_collection
 
 


### PR DESCRIPTION
On termination it is unsafe to call module variables as they may have been set to `None`, so check them first.

Fixes issue #376 