### PR TITLE
Fixes packaging inconsistencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ data = [
     "pydantic>=2.11.7",
 ]
 numba = [
-  "numba>=0.56,<1",
+  "numba>=0.60,<1",
 ]
 pytz = [
     "pytz>=2022.7.1"
@@ -81,7 +81,7 @@ proto = [
 # Package extras
 [project.optional-dependencies]
 numba = [
-  "numba>=0.56,<1",
+  "numba>=0.60,<1",
 ]
 pytz = [
     "pytz>=2022.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 ]
 # following the official NumPy support/deprecation schedule:
 # https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule
+# NOTE: When updating requires-python, also update the py_limited_api wheel config in setup.py
 requires-python = ">=3.11,<4"
 dependencies = [
     "numpy>=2",

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ class fallible_build_ext(build_ext):
 setup(
     cffi_modules=["timezonefinder/build.py:ffibuilder"],
     cmdclass={"build_ext": fallible_build_ext},
-    options={"bdist_wheel": {"py_limited_api": "cp39"} if _abi3 else {}},
+    options={"bdist_wheel": {"py_limited_api": "cp311"} if _abi3 else {}},
 )

--- a/uv.lock
+++ b/uv.lock
@@ -1190,6 +1190,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/a7/8c4f86c78ec03db954d05fd9c57a114cc3a172a2d3e4a8b949cd5ff89471/patchelf-0.17.2.4-py3-none-macosx_10_9_universal2.whl", hash = "sha256:343bb1b94e959f9070ca9607453b04390e36bbaa33c88640b989cefad0aa049e", size = 184436, upload-time = "2025-07-23T21:16:20.578Z" },
     { url = "https://files.pythonhosted.org/packages/7e/19/f7821ef31aab01fa7dc8ebe697ece88ec4f7a0fdd3155dab2dfee4b00e5c/patchelf-0.17.2.4-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:d9b35ebfada70c02679ad036407d9724ffe1255122ba4ac5e4be5868618a5689", size = 482846, upload-time = "2025-07-23T21:16:23.73Z" },
     { url = "https://files.pythonhosted.org/packages/d1/50/107fea848ecfd851d473b079cab79107487d72c4c3cdb25b9d2603a24ca2/patchelf-0.17.2.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:2931a1b5b85f3549661898af7bf746afbda7903c7c9a967cfc998a3563f84fad", size = 477811, upload-time = "2025-07-23T21:16:25.145Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a9/a9a2103e159fd65bffbc21ecc5c8c36e44eb34fe53b4ef85fb6d08c2a635/patchelf-0.17.2.4-py3-none-manylinux2014_armv7l.manylinux_2_17_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:ae44cb3c857d50f54b99e5697aa978726ada33a8a6129d4b8b7ffd28b996652d", size = 431226, upload-time = "2025-07-23T21:16:26.765Z" },
+    { url = "https://files.pythonhosted.org/packages/87/93/897d612f6df7cfd987bdf668425127efeff8d8e4ad8bfbab1c69d2a0d861/patchelf-0.17.2.4-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:680a266a70f60a7a4f4c448482c5bdba80cc8e6bb155a49dcc24238ba49927b0", size = 540276, upload-time = "2025-07-23T21:16:27.983Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b8/2b92d11533482bac9ee989081d6880845287751b5f528adbd6bb27667fbd/patchelf-0.17.2.4-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.musllinux_1_1_s390x.whl", hash = "sha256:d842b51f0401460f3b1f3a3a67d2c266a8f515a5adfbfa6e7b656cb3ac2ed8bc", size = 596632, upload-time = "2025-07-23T21:16:29.253Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/975d4bdb418f942b53e6187b95bd9e0d5e0488b7bc214685a1e43e2c2751/patchelf-0.17.2.4-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:7076d9e127230982e20a81a6e2358d3343004667ba510d9f822d4fdee29b0d71", size = 508281, upload-time = "2025-07-23T21:16:30.865Z" },
 ]
 
 [[package]]
@@ -1925,7 +1929,7 @@ requires-dist = [
     { name = "cffi", specifier = ">=1.15.1,<3" },
     { name = "flatbuffers", specifier = ">=25.2.10" },
     { name = "h3", specifier = ">=4" },
-    { name = "numba", marker = "extra == 'numba'", specifier = ">=0.56,<1" },
+    { name = "numba", marker = "extra == 'numba'", specifier = ">=0.60,<1" },
     { name = "numpy", specifier = ">=2" },
     { name = "pytz", marker = "extra == 'pytz'", specifier = ">=2022.7.1" },
 ]
@@ -1945,7 +1949,7 @@ docs = [
     { name = "sphinx", specifier = ">=8,<10" },
     { name = "sphinx-rtd-theme", specifier = ">=3,<4" },
 ]
-numba = [{ name = "numba", specifier = ">=0.56,<1" }]
+numba = [{ name = "numba", specifier = ">=0.60,<1" }]
 proto = [
     { name = "line-profiler", specifier = ">=5.0.0" },
     { name = "matplotlib", specifier = ">=3.9.4" },


### PR DESCRIPTION
This PR fixes two inconsistencies, which are solved as oneliners.

- setuptools is generating a wheel which is compatible with cpython 3.9 above, but pyproject.toml is stating that the project uses python 3.11 and above (note that platform specific wheel has 'cp39' on it's name);
- numba started to accept numpy 2.0 on version 0.60.