### PR TITLE
Using python 3.10 type hint features

### DIFF
--- a/prototypes/single_resolution_bench.py
+++ b/prototypes/single_resolution_bench.py
@@ -36,7 +36,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import h3.api.numpy_int as h3
 import numpy as np

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -9,7 +9,7 @@ to generate RST reports and handle CLI interfaces.
 import argparse
 import platform
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import Dict, Any
 
 import numpy as np
 
@@ -39,7 +39,7 @@ class BenchmarkReporter:
         self.content.append(("text", text))
         return self
 
-    def add_table(self, headers: List[str], rows: List[List[str]]):
+    def add_table(self, headers: list[str], rows: list[list[str]]):
         """Add a table to the report."""
         self.content.append(("table", headers, rows))
         return self
@@ -105,7 +105,7 @@ Examples:
 
 def format_performance_result(
     name: str, time_per_query: float, queries_per_second: float
-) -> List[str]:
+) -> list[str]:
     """Format performance results for table display."""
     return [
         name,

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -9,7 +9,7 @@ to generate RST reports and handle CLI interfaces.
 import argparse
 import platform
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any
 
 import numpy as np
 
@@ -134,7 +134,7 @@ def print_progress(current: int, total: int, prefix: str = "Progress"):
             print(f"{prefix}: {percent}%")
 
 
-def get_system_status() -> Dict[str, Any]:
+def get_system_status() -> dict[str, Any]:
     """Get comprehensive system status information for benchmark reports."""
     tf_instance = TimezoneFinder()
 
@@ -152,7 +152,7 @@ def get_system_status() -> Dict[str, Any]:
 
 
 def add_system_status_section(
-    reporter: BenchmarkReporter, additional_info: Dict[str, Any] = None
+    reporter: BenchmarkReporter, additional_info: dict[str, Any] = None
 ):
     """Add a comprehensive system status section to a benchmark report."""
     system_info = get_system_status()

--- a/scripts/check_speed_initialisation.py
+++ b/scripts/check_speed_initialisation.py
@@ -8,7 +8,7 @@ and modes. Can be run as a standalone script to generate RST reports or for pyte
 
 import timeit
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -32,7 +32,7 @@ def format_speedup_analysis(
 
 
 def run_initialization_benchmark(
-    n_runs: int = N, data_path: Optional[Path] = None
+    n_runs: int = N, data_path: Path | None = None
 ) -> dict[str, Any]:
     """Run initialization benchmark and return results for RST formatting.
 
@@ -76,7 +76,7 @@ def run_initialization_benchmark(
 
 
 def write_initialization_report(
-    output_path: Path, n_runs: int = N, data_path: Optional[Path] = None
+    output_path: Path, n_runs: int = N, data_path: Path | None = None
 ) -> None:
     """Write a comprehensive initialization benchmark report in RST format.
 

--- a/scripts/check_speed_initialisation.py
+++ b/scripts/check_speed_initialisation.py
@@ -8,7 +8,7 @@ and modes. Can be run as a standalone script to generate RST reports or for pyte
 
 import timeit
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -33,7 +33,7 @@ def format_speedup_analysis(
 
 def run_initialization_benchmark(
     n_runs: int = N, data_path: Optional[Path] = None
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Run initialization benchmark and return results for RST formatting.
 
     Args:

--- a/scripts/check_speed_timezone_finding.py
+++ b/scripts/check_speed_timezone_finding.py
@@ -8,7 +8,7 @@ Can be run as a standalone script to generate RST reports or for pytest executio
 
 import warnings
 from pathlib import Path
-from typing import List, Tuple, Callable, Iterable
+from typing import Tuple, Callable, Iterable
 
 import pytest
 
@@ -33,7 +33,7 @@ N = 10 if DEBUG else int(1e4)
 tf_instance = TimezoneFinder()
 
 # Known land points from test fixtures (lat, lng, description, expected)
-_KNOWN_LAND_POINTS: List[Tuple[float, float]] = [
+_KNOWN_LAND_POINTS: list[Tuple[float, float]] = [
     (lng, lat)
     for lat, lng, _description, expected in TEST_LOCATIONS_AT_LAND
     if expected is not None
@@ -67,7 +67,7 @@ def get_on_land_pts(length: int):
     return on_land_points
 
 
-def get_random_points(length: int) -> List[Tuple[float, float]]:
+def get_random_points(length: int) -> list[Tuple[float, float]]:
     return [get_rnd_query_pt() for _ in range(length)]
 
 
@@ -194,11 +194,11 @@ def test_timezone_finding_speed(
 
 # RST Report Generation Functions
 def run_benchmark_for_rst(
-    test_points: List[Tuple[float, float]],
+    test_points: list[Tuple[float, float]],
     points_descr: str,
     in_memory_mode: bool,
     n_queries: int,
-) -> List[Tuple[str, str, str]]:
+) -> list[Tuple[str, str, str]]:
     """Run benchmark and return results as list of tuples for RST formatting."""
     results = []
 

--- a/scripts/check_speed_timezone_finding.py
+++ b/scripts/check_speed_timezone_finding.py
@@ -8,7 +8,7 @@ Can be run as a standalone script to generate RST reports or for pytest executio
 
 import warnings
 from pathlib import Path
-from typing import Tuple, Callable, Iterable
+from typing import Callable, Iterable
 
 import pytest
 
@@ -33,7 +33,7 @@ N = 10 if DEBUG else int(1e4)
 tf_instance = TimezoneFinder()
 
 # Known land points from test fixtures (lat, lng, description, expected)
-_KNOWN_LAND_POINTS: list[Tuple[float, float]] = [
+_KNOWN_LAND_POINTS: list[tuple[float, float]] = [
     (lng, lat)
     for lat, lng, _description, expected in TEST_LOCATIONS_AT_LAND
     if expected is not None
@@ -67,7 +67,7 @@ def get_on_land_pts(length: int):
     return on_land_points
 
 
-def get_random_points(length: int) -> list[Tuple[float, float]]:
+def get_random_points(length: int) -> list[tuple[float, float]]:
     return [get_rnd_query_pt() for _ in range(length)]
 
 
@@ -194,11 +194,11 @@ def test_timezone_finding_speed(
 
 # RST Report Generation Functions
 def run_benchmark_for_rst(
-    test_points: list[Tuple[float, float]],
+    test_points: list[tuple[float, float]],
     points_descr: str,
     in_memory_mode: bool,
     n_queries: int,
-) -> list[Tuple[str, str, str]]:
+) -> list[tuple[str, str, str]]:
     """Run benchmark and return results as list of tuples for RST formatting."""
     results = []
 

--- a/scripts/configs.py
+++ b/scripts/configs.py
@@ -52,7 +52,9 @@ DTYPE_FORMAT_F_NUMPY = "<f8"
 # Type aliases for better readability and conciseness
 CoordinateArray: TypeAlias = NDArray[np.int32]  # Polygon coordinate arrays
 PolygonList: TypeAlias = list[CoordinateArray]  # List of polygon coordinate arrays
-HoleRegistry: TypeAlias = dict[int, tuple[int, int]]  # Polygon ID -> (num_holes, first_hole_id)
+HoleRegistry: TypeAlias = dict[
+    int, tuple[int, int]
+]  # Polygon ID -> (num_holes, first_hole_id)
 ZoneIdArray: TypeAlias = NDArray[np.unsignedinteger]
 BoundaryArray: TypeAlias = NDArray[np.int32]  # Boundary coordinate array
 LengthList: TypeAlias = list[int]  # List of coordinate counts

--- a/scripts/configs.py
+++ b/scripts/configs.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Set
 from numpy.typing import NDArray
 import numpy as np
 
@@ -31,9 +30,9 @@ SHORTCUT_H3_RES = 0 if DEBUG else SHORTCUT_H3_RES
 DEBUG_ZONE_CTR_STOP = 5  # parse only some polygons in debugging mode
 MAX_LAT = 90.0
 MAX_LNG = 180.0
-HexIdSet = Set[int]
-PolyIdSet = Set[int]
-ZoneIdSet = Set[int]
+HexIdSet = set[int]
+PolyIdSet = set[int]
+ZoneIdSet = set[int]
 
 # BINARY DATA TYPES
 # https://docs.python.org/3/library/struct.html#format-characters

--- a/scripts/configs.py
+++ b/scripts/configs.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import Set
-from typing import Dict, Tuple
+from typing import Tuple
 from numpy.typing import NDArray
 import numpy as np
 
@@ -53,13 +53,13 @@ DTYPE_FORMAT_F_NUMPY = "<f8"
 # Type aliases for better readability and conciseness
 CoordinateArray = NDArray[np.int32]  # Polygon coordinate arrays
 PolygonList = list[CoordinateArray]  # List of polygon coordinate arrays
-HoleRegistry = Dict[int, Tuple[int, int]]  # Polygon ID -> (num_holes, first_hole_id)
+HoleRegistry = dict[int, Tuple[int, int]]  # Polygon ID -> (num_holes, first_hole_id)
 ZoneIdArray = NDArray[np.unsignedinteger]
 BoundaryArray = NDArray[np.int32]  # Boundary coordinate array
 LengthList = list[int]  # List of coordinate counts
 HoleLengthList = list[int]  # List of hole coordinate counts
 PolynrHolesList = list[int]  # List of polygon numbers that have holes
-ShortcutMapping = Dict[int, list[int]]
+ShortcutMapping = dict[int, list[int]]
 
 
 ZONE_ID_DTYPE = DEFAULT_ZONE_ID_DTYPE

--- a/scripts/configs.py
+++ b/scripts/configs.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import TypeAlias
 from numpy.typing import NDArray
 import numpy as np
 
@@ -30,9 +31,9 @@ SHORTCUT_H3_RES = 0 if DEBUG else SHORTCUT_H3_RES
 DEBUG_ZONE_CTR_STOP = 5  # parse only some polygons in debugging mode
 MAX_LAT = 90.0
 MAX_LNG = 180.0
-HexIdSet = set[int]
-PolyIdSet = set[int]
-ZoneIdSet = set[int]
+HexIdSet: TypeAlias = set[int]
+PolyIdSet: TypeAlias = set[int]
+ZoneIdSet: TypeAlias = set[int]
 
 # BINARY DATA TYPES
 # https://docs.python.org/3/library/struct.html#format-characters
@@ -49,15 +50,15 @@ DTYPE_FORMAT_F_NUMPY = "<f8"
 
 
 # Type aliases for better readability and conciseness
-CoordinateArray = NDArray[np.int32]  # Polygon coordinate arrays
-PolygonList = list[CoordinateArray]  # List of polygon coordinate arrays
-HoleRegistry = dict[int, tuple[int, int]]  # Polygon ID -> (num_holes, first_hole_id)
-ZoneIdArray = NDArray[np.unsignedinteger]
-BoundaryArray = NDArray[np.int32]  # Boundary coordinate array
-LengthList = list[int]  # List of coordinate counts
-HoleLengthList = list[int]  # List of hole coordinate counts
-PolynrHolesList = list[int]  # List of polygon numbers that have holes
-ShortcutMapping = dict[int, list[int]]
+CoordinateArray: TypeAlias = NDArray[np.int32]  # Polygon coordinate arrays
+PolygonList: TypeAlias = list[CoordinateArray]  # List of polygon coordinate arrays
+HoleRegistry: TypeAlias = dict[int, tuple[int, int]]  # Polygon ID -> (num_holes, first_hole_id)
+ZoneIdArray: TypeAlias = NDArray[np.unsignedinteger]
+BoundaryArray: TypeAlias = NDArray[np.int32]  # Boundary coordinate array
+LengthList: TypeAlias = list[int]  # List of coordinate counts
+HoleLengthList: TypeAlias = list[int]  # List of hole coordinate counts
+PolynrHolesList: TypeAlias = list[int]  # List of polygon numbers that have holes
+ShortcutMapping: TypeAlias = dict[int, list[int]]
 
 
 ZONE_ID_DTYPE = DEFAULT_ZONE_ID_DTYPE

--- a/scripts/configs.py
+++ b/scripts/configs.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Set
-from typing import Tuple
 from numpy.typing import NDArray
 import numpy as np
 
@@ -53,7 +52,7 @@ DTYPE_FORMAT_F_NUMPY = "<f8"
 # Type aliases for better readability and conciseness
 CoordinateArray = NDArray[np.int32]  # Polygon coordinate arrays
 PolygonList = list[CoordinateArray]  # List of polygon coordinate arrays
-HoleRegistry = dict[int, Tuple[int, int]]  # Polygon ID -> (num_holes, first_hole_id)
+HoleRegistry = dict[int, tuple[int, int]]  # Polygon ID -> (num_holes, first_hole_id)
 ZoneIdArray = NDArray[np.unsignedinteger]
 BoundaryArray = NDArray[np.int32]  # Boundary coordinate array
 LengthList = list[int]  # List of coordinate counts

--- a/scripts/configs.py
+++ b/scripts/configs.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import Set
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 from numpy.typing import NDArray
 import numpy as np
 
@@ -52,14 +52,14 @@ DTYPE_FORMAT_F_NUMPY = "<f8"
 
 # Type aliases for better readability and conciseness
 CoordinateArray = NDArray[np.int32]  # Polygon coordinate arrays
-PolygonList = List[CoordinateArray]  # List of polygon coordinate arrays
+PolygonList = list[CoordinateArray]  # List of polygon coordinate arrays
 HoleRegistry = Dict[int, Tuple[int, int]]  # Polygon ID -> (num_holes, first_hole_id)
 ZoneIdArray = NDArray[np.unsignedinteger]
 BoundaryArray = NDArray[np.int32]  # Boundary coordinate array
-LengthList = List[int]  # List of coordinate counts
-HoleLengthList = List[int]  # List of hole coordinate counts
-PolynrHolesList = List[int]  # List of polygon numbers that have holes
-ShortcutMapping = Dict[int, List[int]]
+LengthList = list[int]  # List of coordinate counts
+HoleLengthList = list[int]  # List of hole coordinate counts
+PolynrHolesList = list[int]  # List of polygon numbers that have holes
+ShortcutMapping = Dict[int, list[int]]
 
 
 ZONE_ID_DTYPE = DEFAULT_ZONE_ID_DTYPE

--- a/scripts/file_converter.py
+++ b/scripts/file_converter.py
@@ -37,7 +37,7 @@ in res=3 it takes only slightly more space to store just the highest resolution 
 """
 
 from pathlib import Path
-from typing import Any, Tuple, Union
+from typing import Any, Union
 from numpy.typing import NDArray
 
 import numpy as np
@@ -112,7 +112,7 @@ def to_bbox_vector(values: list[int]) -> BoundaryArray:
 
 def convert_bboxes_to_numpy(
     bboxes: list[Boundaries],
-) -> Tuple[BoundaryArray, BoundaryArray, BoundaryArray, BoundaryArray]:
+) -> tuple[BoundaryArray, BoundaryArray, BoundaryArray, BoundaryArray]:
     """Converts a list of Boundaries to numpy arrays for xmax, xmin, ymax, ymin.
     Args:
         bboxes: List of Boundaries objects

--- a/scripts/file_converter.py
+++ b/scripts/file_converter.py
@@ -37,7 +37,7 @@ in res=3 it takes only slightly more space to store just the highest resolution 
 """
 
 from pathlib import Path
-from typing import Any, List, Tuple, Union
+from typing import Any, Tuple, Union
 from numpy.typing import NDArray
 
 import numpy as np
@@ -94,7 +94,7 @@ def create_and_write_hole_registry(data: TimezoneData, output_path: Path) -> Non
     write_json(data.hole_registry, path)
 
 
-def to_numpy_array(values: List[Any], dtype: str) -> NDArray[Any]:
+def to_numpy_array(values: list[Any], dtype: str) -> NDArray[Any]:
     """
     Converts a list of values to a numpy array with the specified dtype.
     Args:
@@ -106,12 +106,12 @@ def to_numpy_array(values: List[Any], dtype: str) -> NDArray[Any]:
     return np.array(values, dtype=dtype)
 
 
-def to_bbox_vector(values: List[int]) -> BoundaryArray:
+def to_bbox_vector(values: list[int]) -> BoundaryArray:
     return to_numpy_array(values, dtype=DTYPE_FORMAT_SIGNED_I_NUMPY)
 
 
 def convert_bboxes_to_numpy(
-    bboxes: List[Boundaries],
+    bboxes: list[Boundaries],
 ) -> Tuple[BoundaryArray, BoundaryArray, BoundaryArray, BoundaryArray]:
     """Converts a list of Boundaries to numpy arrays for xmax, xmin, ymax, ymin.
     Args:
@@ -119,10 +119,10 @@ def convert_bboxes_to_numpy(
     Returns:
         Tuple of numpy arrays (xmax, xmin, ymax, ymin)
     """
-    xmax_list: List[int] = []
-    xmin_list: List[int] = []
-    ymax_list: List[int] = []
-    ymin_list: List[int] = []
+    xmax_list: list[int] = []
+    xmin_list: list[int] = []
+    ymax_list: list[int] = []
+    ymin_list: list[int] = []
     for bounds in bboxes:
         xmax_list.append(bounds.xmax)
         xmin_list.append(bounds.xmin)

--- a/scripts/file_converter.py
+++ b/scripts/file_converter.py
@@ -37,7 +37,7 @@ in res=3 it takes only slightly more space to store just the highest resolution 
 """
 
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 from numpy.typing import NDArray
 
 import numpy as np
@@ -135,7 +135,7 @@ def convert_bboxes_to_numpy(
     return xmax, xmin, ymax, ymin
 
 
-def _coerce_zone_id_dtype(zone_id_dtype: Union[str, np.dtype, None]) -> np.dtype:
+def _coerce_zone_id_dtype(zone_id_dtype: str | np.dtype | None) -> np.dtype:
     """Normalise zone id dtype configuration into a numpy dtype."""
 
     if zone_id_dtype is None:
@@ -236,9 +236,9 @@ def compile_data_files(data: TimezoneData, output_path: Path) -> None:
 
 @time_execution
 def parse_data(
-    input_path: Union[Path, str] = DEFAULT_INPUT_PATH,
-    output_path: Union[Path, str] = DEFAULT_DATA_DIR,
-    zone_id_dtype: Union[str, np.dtype, None] = ZONE_ID_DTYPE_NAME,
+    input_path: Path | str = DEFAULT_INPUT_PATH,
+    output_path: Path | str = DEFAULT_DATA_DIR,
+    zone_id_dtype: str | np.dtype | None = ZONE_ID_DTYPE_NAME,
 ) -> None:
     input_path_obj: Path = Path(input_path)
     output_path_obj: Path = Path(output_path)

--- a/scripts/helper_classes.py
+++ b/scripts/helper_classes.py
@@ -1,4 +1,4 @@
-from typing import List, NamedTuple, Union
+from typing import NamedTuple, Union
 import numpy as np
 
 from typing import Literal
@@ -18,7 +18,7 @@ class PolygonGeometry(BaseModel):
 
     type: Literal["Polygon"]
     # depth: 3
-    coordinates: List[List[List[float]]]
+    coordinates: list[list[list[float]]]
 
 
 class MultiPolygonGeometry(BaseModel):
@@ -26,7 +26,7 @@ class MultiPolygonGeometry(BaseModel):
 
     type: Literal["MultiPolygon"]
     # depth: 4
-    coordinates: List[List[List[List[float]]]]
+    coordinates: list[list[list[list[float]]]]
 
 
 class Timezone(BaseModel):
@@ -41,7 +41,7 @@ class GeoJSON(BaseModel):
     """schema for a timezone dataset in GeoJSON format"""
 
     type: Literal["FeatureCollection"]
-    features: List[Timezone]
+    features: list[Timezone]
 
 
 class Boundaries(NamedTuple):
@@ -64,9 +64,9 @@ class Boundaries(NamedTuple):
         return True
 
 
-def compile_bboxes(coord_list: PolygonList) -> List[Boundaries]:
+def compile_bboxes(coord_list: PolygonList) -> list[Boundaries]:
     # print("compiling the bounding boxes of the polygons from the coordinates...")
-    boundaries: List[Boundaries] = []
+    boundaries: list[Boundaries] = []
     for coords in coord_list:
         x_coords, y_coords = coords
         y_coords = coords[1]

--- a/scripts/helper_classes.py
+++ b/scripts/helper_classes.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Union
+from typing import NamedTuple
 import numpy as np
 
 from typing import Literal
@@ -34,7 +34,7 @@ class Timezone(BaseModel):
 
     type: Literal["Feature"]
     id: str = Field(..., validation_alias=AliasPath("properties", "tzid"))
-    geometry: Union[PolygonGeometry, MultiPolygonGeometry]
+    geometry: PolygonGeometry | MultiPolygonGeometry
 
 
 class GeoJSON(BaseModel):

--- a/scripts/hex_utils.py
+++ b/scripts/hex_utils.py
@@ -3,7 +3,7 @@ Hex-related utility functions that don't depend on classes.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -104,9 +104,9 @@ class Hex:
     surr_n_pole: bool
     surr_s_pole: bool
     data: "TimezoneData"
-    _poly_candidates: Optional[PolyIdSet] = None
-    _polys_in_cell: Optional[PolyIdSet] = None
-    _zones_in_cell: Optional[ZoneIdSet] = None
+    _poly_candidates: PolyIdSet | None = None
+    _polys_in_cell: PolyIdSet | None = None
+    _zones_in_cell: ZoneIdSet | None = None
 
     @classmethod
     def from_id(cls, id: int, data: "TimezoneData"):

--- a/scripts/hex_utils.py
+++ b/scripts/hex_utils.py
@@ -3,7 +3,7 @@ Hex-related utility functions that don't depend on classes.
 """
 
 from dataclasses import dataclass
-from typing import Set, TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -163,7 +163,7 @@ class Hex:
         return overlapping
 
     @property
-    def poly_candidates(self) -> Set[int]:
+    def poly_candidates(self) -> set[int]:
         candidates = self._poly_candidates
         if candidates is None:
             self._init_candidates()
@@ -203,14 +203,14 @@ class Hex:
         return overlap
 
     @property
-    def polys_in_cell(self) -> Set[int]:
+    def polys_in_cell(self) -> set[int]:
         if self._polys_in_cell is None:
             # lazy evaluation, caching
             self._polys_in_cell = set(filter(self.lies_in_cell, self.poly_candidates))
         return self._polys_in_cell
 
     @property
-    def zones_in_cell(self) -> Set[int]:
+    def zones_in_cell(self) -> set[int]:
         if self._zones_in_cell is None:
             # lazy evaluation, caching
             self._zones_in_cell = {

--- a/scripts/hex_utils.py
+++ b/scripts/hex_utils.py
@@ -3,7 +3,7 @@ Hex-related utility functions that don't depend on classes.
 """
 
 from dataclasses import dataclass
-from typing import Set, Tuple, TYPE_CHECKING, Optional
+from typing import Set, TYPE_CHECKING, Optional
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -43,7 +43,7 @@ def surrounds_south_pole(hex_id: int) -> bool:
 
 def get_corrected_hex_boundaries(
     x_coords, y_coords, surr_n_pole, surr_s_pole
-) -> Tuple[Boundaries, bool]:
+) -> tuple[Boundaries, bool]:
     """boundaries of a hex cell used for pre-filtering the polygons
     which have to be checked with expensive point-in-polygon algorithm
 

--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -8,7 +8,7 @@ import json
 from collections import Counter
 from contextlib import redirect_stdout
 from pathlib import Path
-from typing import Callable, Dict, List, Union
+from typing import Callable, Dict, Union
 
 import numpy as np
 
@@ -183,7 +183,7 @@ def rst_title(title: str, level: int = 0) -> str:
     return f"\n\n{title}\n{sep * len(title)}\n"
 
 
-def print_rst_table(headers: List[str], rows: List[List[str]]):
+def print_rst_table(headers: list[str], rows: list[list[str]]):
     """
     Print a table in restructured text (.rst) format using list-table directive
 
@@ -213,7 +213,7 @@ def print_rst_table(headers: List[str], rows: List[List[str]]):
     print("")
 
 
-def print_frequencies(counts: List[int], label: str):
+def print_frequencies(counts: list[int], label: str):
     max_val = max(*counts)
     frequencies = [counts.count(i) for i in range(max_val + 1)]
 
@@ -255,7 +255,7 @@ def get_file_size_in_mb(file_path: Path) -> float:
 
 
 def calculate_shortcut_index_stats(
-    mapping: Dict[int, Union[int, np.ndarray]], poly_zone_ids: List[int]
+    mapping: Dict[int, Union[int, np.ndarray]], poly_zone_ids: list[int]
 ) -> Dict[str, Union[int, float]]:
     """
     Calculate comprehensive statistics about the hybrid shortcut index.
@@ -405,7 +405,7 @@ def calculate_shortcut_index_stats(
 
 @redirect_output_to_file(DATA_REPORT_FILE)
 def print_shortcut_statistics(
-    mapping: Dict[int, Union[int, np.ndarray]], poly_zone_ids: List[int]
+    mapping: Dict[int, Union[int, np.ndarray]], poly_zone_ids: list[int]
 ):
     print(rst_title("Shortcut Mapping Statistics", level=1))
 
@@ -452,7 +452,7 @@ def print_shortcut_statistics(
     print_frequencies(stats["zones_per_shortcut"], "timezones/shortcut")
 
 
-def generate_metrics_rows(metric_type: str, metrics_dict: Dict) -> List[List]:
+def generate_metrics_rows(metric_type: str, metrics_dict: Dict) -> list[list]:
     """
     Generate additional metric rows for tables based on a dictionary of metrics.
 
@@ -479,7 +479,7 @@ def generate_metrics_rows(metric_type: str, metrics_dict: Dict) -> List[List]:
 
 
 def generate_polygon_statistics_table(
-    polygon_type: str, count: int, length_list: List[int], additional_rows: List = None
+    polygon_type: str, count: int, length_list: list[int], additional_rows: list = None
 ) -> None:
     """
     Generate and print a table with statistics for a polygon collection.
@@ -537,7 +537,7 @@ def generate_polygon_statistics_table(
 
 
 def calculate_general_statistics(
-    polygon_lengths: List[int], all_hole_lengths: List[int]
+    polygon_lengths: list[int], all_hole_lengths: list[int]
 ) -> Dict:
     """
     Calculate general statistics about the dataset.
@@ -557,7 +557,7 @@ def calculate_general_statistics(
 
 
 def calculate_hole_metrics(
-    nr_of_polygons: int, all_hole_lengths: List[int], polynrs_of_holes: List[int]
+    nr_of_polygons: int, all_hole_lengths: list[int], polynrs_of_holes: list[int]
 ) -> Dict:
     """
     Calculate statistics about holes in the dataset.
@@ -626,8 +626,8 @@ def calculate_timezone_metrics(
 
 def print_polygon_distribution_table(
     polygons_per_timezone: Counter,
-    all_tz_names: List[str],
-) -> List[List[str]]:
+    all_tz_names: list[str],
+) -> list[list[str]]:
     """
     Create a table showing the distribution of polygon counts across timezones.
 
@@ -683,11 +683,11 @@ def print_polygon_distribution_table(
 def report_data_statistics(
     nr_of_polygons: int,
     nr_of_zones: int,
-    polygon_lengths: List[int],
-    all_hole_lengths: List[int],
-    polynrs_of_holes: List[int],
-    poly_zone_ids: List[int],
-    all_tz_names: List[str],
+    polygon_lengths: list[int],
+    all_hole_lengths: list[int],
+    polynrs_of_holes: list[int],
+    poly_zone_ids: list[int],
+    all_tz_names: list[str],
 ) -> None:
     """
     Prints a report of the statistics of the timezone data.

--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -8,7 +8,7 @@ import json
 from collections import Counter
 from contextlib import redirect_stdout
 from pathlib import Path
-from typing import Callable, Union
+from typing import Callable
 
 import numpy as np
 
@@ -53,7 +53,7 @@ def redirect_output_to_file(file_path: str) -> Callable:
 
 
 # context manager version for direct output redirection
-def redirect_output_to_file_contextmanager(file_path: Union[str, Path]):
+def redirect_output_to_file_contextmanager(file_path: str | Path):
     """Context manager to redirect stdout to a file."""
     import sys
     from contextlib import contextmanager
@@ -255,8 +255,8 @@ def get_file_size_in_mb(file_path: Path) -> float:
 
 
 def calculate_shortcut_index_stats(
-    mapping: dict[int, Union[int, np.ndarray]], poly_zone_ids: list[int]
-) -> dict[str, Union[int, float]]:
+    mapping: dict[int, int | np.ndarray], poly_zone_ids: list[int]
+) -> dict[str, int | float]:
     """
     Calculate comprehensive statistics about the hybrid shortcut index.
 
@@ -405,7 +405,7 @@ def calculate_shortcut_index_stats(
 
 @redirect_output_to_file(DATA_REPORT_FILE)
 def print_shortcut_statistics(
-    mapping: dict[int, Union[int, np.ndarray]], poly_zone_ids: list[int]
+    mapping: dict[int, int | np.ndarray], poly_zone_ids: list[int]
 ):
     print(rst_title("Shortcut Mapping Statistics", level=1))
 

--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -452,7 +452,7 @@ def print_shortcut_statistics(
     print_frequencies(stats["zones_per_shortcut"], "timezones/shortcut")
 
 
-def generate_metrics_rows(metric_type: str, metrics_dict: Dict) -> list[list]:
+def generate_metrics_rows(metric_type: str, metrics_dict: dict) -> list[list]:
     """
     Generate additional metric rows for tables based on a dictionary of metrics.
 
@@ -538,7 +538,7 @@ def generate_polygon_statistics_table(
 
 def calculate_general_statistics(
     polygon_lengths: list[int], all_hole_lengths: list[int]
-) -> Dict:
+) -> dict:
     """
     Calculate general statistics about the dataset.
 
@@ -558,7 +558,7 @@ def calculate_general_statistics(
 
 def calculate_hole_metrics(
     nr_of_polygons: int, all_hole_lengths: list[int], polynrs_of_holes: list[int]
-) -> Dict:
+) -> dict:
     """
     Calculate statistics about holes in the dataset.
 
@@ -592,7 +592,7 @@ def calculate_timezone_metrics(
     nr_of_zones: int,
     nr_of_polygons: int,
     polygons_per_timezone: Counter,
-) -> Dict:
+) -> dict:
     """
     Calculate statistics about timezones in the dataset.
 

--- a/scripts/reporting.py
+++ b/scripts/reporting.py
@@ -8,7 +8,7 @@ import json
 from collections import Counter
 from contextlib import redirect_stdout
 from pathlib import Path
-from typing import Callable, Dict, Union
+from typing import Callable, Union
 
 import numpy as np
 
@@ -71,7 +71,7 @@ def redirect_output_to_file_contextmanager(file_path: Union[str, Path]):
     return _redirect()
 
 
-def load_binary_data(data_path: Path = DEFAULT_DATA_DIR) -> Dict:
+def load_binary_data(data_path: Path = DEFAULT_DATA_DIR) -> dict:
     """
     Load all necessary data from binary files to generate reports.
 
@@ -255,8 +255,8 @@ def get_file_size_in_mb(file_path: Path) -> float:
 
 
 def calculate_shortcut_index_stats(
-    mapping: Dict[int, Union[int, np.ndarray]], poly_zone_ids: list[int]
-) -> Dict[str, Union[int, float]]:
+    mapping: dict[int, Union[int, np.ndarray]], poly_zone_ids: list[int]
+) -> dict[str, Union[int, float]]:
     """
     Calculate comprehensive statistics about the hybrid shortcut index.
 
@@ -405,7 +405,7 @@ def calculate_shortcut_index_stats(
 
 @redirect_output_to_file(DATA_REPORT_FILE)
 def print_shortcut_statistics(
-    mapping: Dict[int, Union[int, np.ndarray]], poly_zone_ids: list[int]
+    mapping: dict[int, Union[int, np.ndarray]], poly_zone_ids: list[int]
 ):
     print(rst_title("Shortcut Mapping Statistics", level=1))
 

--- a/scripts/shortcuts.py
+++ b/scripts/shortcuts.py
@@ -4,7 +4,7 @@ import itertools
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, Set, Tuple, Union
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -91,7 +91,7 @@ def get_corrected_hex_boundaries(
 
 
 @profile
-def optimise_shortcut_ordering(data: TimezoneData, poly_ids: List[int]) -> List[int]:
+def optimise_shortcut_ordering(data: TimezoneData, poly_ids: list[int]) -> list[int]:
     """optimises the order of polygon ids for faster timezone checks
 
     observation: as soon as just polygons of one zone are left, this zone can be returned
@@ -117,7 +117,7 @@ def optimise_shortcut_ordering(data: TimezoneData, poly_ids: List[int]) -> List[
 
     zone_ids_sorted = sorted(zone_buckets, key=zone_sizes.__getitem__)
     get_length = polygon_lengths.__getitem__
-    poly_ids_sorted: List[int] = []
+    poly_ids_sorted: list[int] = []
 
     for zone_id in zone_ids_sorted:
         zone_poly_ids = zone_buckets[zone_id]
@@ -127,7 +127,7 @@ def optimise_shortcut_ordering(data: TimezoneData, poly_ids: List[int]) -> List[
     return poly_ids_sorted
 
 
-def has_coherent_sequences(lst: List[int]) -> bool:
+def has_coherent_sequences(lst: list[int]) -> bool:
     """
     :return: True if equal entries in the list are not separated by entries of other values
     """
@@ -160,7 +160,7 @@ def check_shortcut_sorting(polygon_ids: np.ndarray, all_zone_ids: np.ndarray):
 
 
 @profile
-def process_single_hex(hex_id: int, data: TimezoneData) -> Tuple[int, List[int]]:
+def process_single_hex(hex_id: int, data: TimezoneData) -> Tuple[int, list[int]]:
     """
     Process a single hex cell to find its polygon shortcuts.
 
@@ -276,7 +276,7 @@ def compute_unique_shortcut_mapping(
 
 def build_hybrid_index_from_separate_indices(
     shortcuts: ShortcutMapping, unique_shortcuts: Dict[int, int]
-) -> Dict[int, Union[int, List[int]]]:
+) -> Dict[int, Union[int, list[int]]]:
     """Build hybrid index from separate shortcuts and unique_shortcuts indices.
 
     This algorithm combines the two legacy data structures into a single hybrid
@@ -302,7 +302,7 @@ def build_hybrid_index_from_separate_indices(
     Returns:
         Dictionary mapping hex IDs to either:
         - int: zone ID (for unique cases where all polygons share same zone)
-        - List[int]: polygon IDs (for ambiguous cases requiring polygon tests)
+        - list[int]: polygon IDs (for ambiguous cases requiring polygon tests)
     """
     hybrid_mapping = {}
 
@@ -325,7 +325,7 @@ def compile_hybrid_shortcuts(
     unique_shortcuts: Dict[int, int],
     zone_id_dtype: np.dtype,
     output_path: Path,
-) -> Dict[int, Union[int, List[int]]]:
+) -> Dict[int, Union[int, list[int]]]:
     """Compile hybrid shortcuts combining legacy shortcuts and unique_shortcuts.
 
     Args:

--- a/scripts/shortcuts.py
+++ b/scripts/shortcuts.py
@@ -4,7 +4,6 @@ import itertools
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Union
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -276,7 +275,7 @@ def compute_unique_shortcut_mapping(
 
 def build_hybrid_index_from_separate_indices(
     shortcuts: ShortcutMapping, unique_shortcuts: dict[int, int]
-) -> dict[int, Union[int, list[int]]]:
+) -> dict[int, int | list[int]]:
     """Build hybrid index from separate shortcuts and unique_shortcuts indices.
 
     This algorithm combines the two legacy data structures into a single hybrid
@@ -325,7 +324,7 @@ def compile_hybrid_shortcuts(
     unique_shortcuts: dict[int, int],
     zone_id_dtype: np.dtype,
     output_path: Path,
-) -> dict[int, Union[int, list[int]]]:
+) -> dict[int, int | list[int]]:
     """Compile hybrid shortcuts combining legacy shortcuts and unique_shortcuts.
 
     Args:

--- a/scripts/shortcuts.py
+++ b/scripts/shortcuts.py
@@ -4,7 +4,7 @@ import itertools
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Set, Tuple, Union
+from typing import Set, Union
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -40,7 +40,7 @@ except NameError:  # pragma: no cover - used only during profiling
 
 def get_corrected_hex_boundaries(
     x_coords, y_coords, surr_n_pole, surr_s_pole
-) -> Tuple["Boundaries", bool]:
+) -> tuple["Boundaries", bool]:
     """boundaries of a hex cell used for pre-filtering the polygons
     which have to be checked with expensive point-in-polygon algorithm
 
@@ -160,7 +160,7 @@ def check_shortcut_sorting(polygon_ids: np.ndarray, all_zone_ids: np.ndarray):
 
 
 @profile
-def process_single_hex(hex_id: int, data: TimezoneData) -> Tuple[int, list[int]]:
+def process_single_hex(hex_id: int, data: TimezoneData) -> tuple[int, list[int]]:
     """
     Process a single hex cell to find its polygon shortcuts.
 

--- a/scripts/shortcuts.py
+++ b/scripts/shortcuts.py
@@ -4,7 +4,7 @@ import itertools
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Set, Union
+from typing import Union
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -180,7 +180,7 @@ def process_single_hex(hex_id: int, data: TimezoneData) -> tuple[int, list[int]]
 
 
 @profile
-def compile_h3_map(data: TimezoneData, candidates: Set[int]) -> ShortcutMapping:
+def compile_h3_map(data: TimezoneData, candidates: set[int]) -> ShortcutMapping:
     """
     operate on one hex resolution
     also store results separately to divide the output data files

--- a/scripts/shortcuts.py
+++ b/scripts/shortcuts.py
@@ -4,7 +4,7 @@ import itertools
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Set, Tuple, Union
+from typing import Set, Tuple, Union
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -259,10 +259,10 @@ def compile_shortcut_mapping(
 
 def compute_unique_shortcut_mapping(
     shortcuts: ShortcutMapping, zone_ids: np.ndarray
-) -> Dict[int, int]:
+) -> dict[int, int]:
     """Derive a mapping from hex id to a unique zone id when present."""
 
-    unique_map: Dict[int, int] = {}
+    unique_map: dict[int, int] = {}
     for hex_id, polygon_ids in shortcuts.items():
         if len(polygon_ids) == 0:
             continue
@@ -275,8 +275,8 @@ def compute_unique_shortcut_mapping(
 
 
 def build_hybrid_index_from_separate_indices(
-    shortcuts: ShortcutMapping, unique_shortcuts: Dict[int, int]
-) -> Dict[int, Union[int, list[int]]]:
+    shortcuts: ShortcutMapping, unique_shortcuts: dict[int, int]
+) -> dict[int, Union[int, list[int]]]:
     """Build hybrid index from separate shortcuts and unique_shortcuts indices.
 
     This algorithm combines the two legacy data structures into a single hybrid
@@ -322,10 +322,10 @@ def build_hybrid_index_from_separate_indices(
 
 def compile_hybrid_shortcuts(
     shortcuts: ShortcutMapping,
-    unique_shortcuts: Dict[int, int],
+    unique_shortcuts: dict[int, int],
     zone_id_dtype: np.dtype,
     output_path: Path,
-) -> Dict[int, Union[int, list[int]]]:
+) -> dict[int, Union[int, list[int]]]:
     """Compile hybrid shortcuts combining legacy shortcuts and unique_shortcuts.
 
     Args:

--- a/scripts/timezone_data.py
+++ b/scripts/timezone_data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional, Set, Tuple
+from typing import Any, Optional, Set
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -286,7 +286,7 @@ class TimezoneData(BaseModel):
     @classmethod
     def _process_hole(
         cls,
-        hole: list[list[Tuple[float, float]]],
+        hole: list[list[tuple[float, float]]],
         poly_id: int,
         hole_nr: int,
         nr_of_holes: int,
@@ -311,7 +311,7 @@ class TimezoneData(BaseModel):
     @classmethod
     def _process_polygon_with_holes(
         cls,
-        poly_with_hole: list[list[list[Tuple[float, float]]]],
+        poly_with_hole: list[list[list[tuple[float, float]]]],
         zone_id: int,
         tz_name: str,
         poly_id: int,
@@ -373,7 +373,7 @@ class TimezoneData(BaseModel):
         holes: PolygonList,
         all_hole_lengths: HoleLengthList,
         original_polygons: list[np.ndarray],
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         tz_name = timezone.id
         all_tz_names.append(tz_name)
         tz_geometry = timezone.geometry

--- a/scripts/timezone_data.py
+++ b/scripts/timezone_data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Optional, Set, Tuple
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -44,7 +44,7 @@ def _validate_numpy_polygons(polygons: PolygonList, kind: str) -> None:
             raise ValueError(f"{kind} polygon array must have shape (2, N)")
 
 
-def _validate_lengths(lengths: List[int], kind: str, minimum: int) -> None:
+def _validate_lengths(lengths: list[int], kind: str, minimum: int) -> None:
     if any(length == 0 for length in lengths):
         raise ValueError(f"Found a {kind} with no coordinates")
     if any(length < minimum for length in lengths):
@@ -54,7 +54,7 @@ def _validate_lengths(lengths: List[int], kind: str, minimum: int) -> None:
 class ZoneCollection(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    names: List[str]
+    names: list[str]
     poly_zone_ids: ZoneIdArray
     dtype_str: str = ZONE_ID_DTYPE_NUMPY_FORMAT
 
@@ -107,8 +107,8 @@ class ZoneCollection(BaseModel):
     def nr_of_polygons(self) -> int:
         return int(self.poly_zone_ids.size)
 
-    def zone_positions(self) -> List[int]:
-        positions: List[int] = []
+    def zone_positions(self) -> list[int]:
+        positions: list[int] = []
         last_id = -1
         for poly_idx, zone_id in enumerate(self.poly_zone_ids):
             zone_int = int(zone_id)
@@ -128,8 +128,8 @@ class PolygonCollection(BaseModel):
 
     polygons: PolygonList
     lengths: LengthList
-    original_polygons: Optional[List[np.ndarray]] = None
-    _boundaries: Optional[List[Boundaries]] = PrivateAttr(default=None)
+    original_polygons: Optional[list[np.ndarray]] = None
+    _boundaries: Optional[list[Boundaries]] = PrivateAttr(default=None)
     _vertex_hex_cache: Dict[int, Dict[int, Set[int]]] = PrivateAttr(
         default_factory=dict
     )
@@ -163,7 +163,7 @@ class PolygonCollection(BaseModel):
         return len(self.lengths)
 
     @property
-    def boundaries(self) -> List[Boundaries]:
+    def boundaries(self) -> list[Boundaries]:
         if self._boundaries is None:
             self._boundaries = compile_bboxes(self.polygons)
         return self._boundaries
@@ -187,7 +187,7 @@ class HoleCollection(BaseModel):
     holes: PolygonList
     lengths: HoleLengthList
     polynrs_of_holes: PolynrHolesList
-    _boundaries: Optional[List[Boundaries]] = PrivateAttr(default=None)
+    _boundaries: Optional[list[Boundaries]] = PrivateAttr(default=None)
     _registry: Optional[HoleRegistry] = PrivateAttr(default=None)
 
     @field_validator("holes")
@@ -217,7 +217,7 @@ class HoleCollection(BaseModel):
         return len(self.lengths)
 
     @property
-    def boundaries(self) -> List[Boundaries]:
+    def boundaries(self) -> list[Boundaries]:
         if self._boundaries is None:
             self._boundaries = compile_bboxes(self.holes)
         return self._boundaries
@@ -286,7 +286,7 @@ class TimezoneData(BaseModel):
     @classmethod
     def _process_hole(
         cls,
-        hole: List[List[Tuple[float, float]]],
+        hole: list[list[Tuple[float, float]]],
         poly_id: int,
         hole_nr: int,
         nr_of_holes: int,
@@ -311,18 +311,18 @@ class TimezoneData(BaseModel):
     @classmethod
     def _process_polygon_with_holes(
         cls,
-        poly_with_hole: List[List[List[Tuple[float, float]]]],
+        poly_with_hole: list[list[list[Tuple[float, float]]]],
         zone_id: int,
         tz_name: str,
         poly_id: int,
         polygons: PolygonList,
         polygon_lengths: LengthList,
-        poly_zone_ids: List[int],
+        poly_zone_ids: list[int],
         nr_of_holes: int,
         polynrs_of_holes: PolynrHolesList,
         holes: PolygonList,
         all_hole_lengths: HoleLengthList,
-        original_polygons: List[np.ndarray],
+        original_polygons: list[np.ndarray],
     ) -> int:
         original_boundary_coords = poly_with_hole[0]
         x_coords_orig, y_coords_orig = zip(*original_boundary_coords)
@@ -364,15 +364,15 @@ class TimezoneData(BaseModel):
         zone_id: int,
         timezone: Any,
         poly_id: int,
-        all_tz_names: List[str],
+        all_tz_names: list[str],
         polygons: PolygonList,
         polygon_lengths: LengthList,
-        poly_zone_ids: List[int],
+        poly_zone_ids: list[int],
         nr_of_holes: int,
         polynrs_of_holes: PolynrHolesList,
         holes: PolygonList,
         all_hole_lengths: HoleLengthList,
-        original_polygons: List[np.ndarray],
+        original_polygons: list[np.ndarray],
     ) -> Tuple[int, int]:
         tz_name = timezone.id
         all_tz_names.append(tz_name)
@@ -419,15 +419,15 @@ class TimezoneData(BaseModel):
                 f"Zone ID dtype must be unsigned integer, got {zone_id_dtype}"
             )
 
-        all_tz_names: List[str] = []
+        all_tz_names: list[str] = []
         polygons: PolygonList = []
         polygon_lengths: LengthList = []
-        poly_zone_ids: List[int] = []
+        poly_zone_ids: list[int] = []
         nr_of_holes: int = 0
         polynrs_of_holes: PolynrHolesList = []
         holes: PolygonList = []
         all_hole_lengths: HoleLengthList = []
-        original_polygons: List[np.ndarray] = []
+        original_polygons: list[np.ndarray] = []
 
         poly_id: int = 0
         print("parsing data...\nprocessing holes:")
@@ -511,7 +511,7 @@ class TimezoneData(BaseModel):
         return self
 
     @property
-    def all_tz_names(self) -> List[str]:
+    def all_tz_names(self) -> list[str]:
         return self.zones.names
 
     @property
@@ -543,7 +543,7 @@ class TimezoneData(BaseModel):
         return self.hole_store.polynrs_of_holes
 
     @property
-    def original_polygons(self) -> Optional[List[np.ndarray]]:
+    def original_polygons(self) -> Optional[list[np.ndarray]]:
         return self.polygon_store.original_polygons
 
     @property
@@ -559,15 +559,15 @@ class TimezoneData(BaseModel):
         return self.hole_store.nr_of_holes
 
     @property
-    def poly_boundaries(self) -> List[Boundaries]:
+    def poly_boundaries(self) -> list[Boundaries]:
         return self.polygon_store.boundaries
 
     @property
-    def hole_boundaries(self) -> List[Boundaries]:
+    def hole_boundaries(self) -> list[Boundaries]:
         return self.hole_store.boundaries
 
     @property
-    def zone_positions(self) -> List[int]:
+    def zone_positions(self) -> list[int]:
         print("Computing where zones start and end...")
         positions = self.zones.zone_positions()
         print("...Done.\n")

--- a/scripts/timezone_data.py
+++ b/scripts/timezone_data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -128,8 +128,8 @@ class PolygonCollection(BaseModel):
 
     polygons: PolygonList
     lengths: LengthList
-    original_polygons: Optional[list[np.ndarray]] = None
-    _boundaries: Optional[list[Boundaries]] = PrivateAttr(default=None)
+    original_polygons: list[np.ndarray] | None = None
+    _boundaries: list[Boundaries] | None = PrivateAttr(default=None)
     _vertex_hex_cache: dict[int, dict[int, set[int]]] = PrivateAttr(
         default_factory=dict
     )
@@ -187,8 +187,8 @@ class HoleCollection(BaseModel):
     holes: PolygonList
     lengths: HoleLengthList
     polynrs_of_holes: PolynrHolesList
-    _boundaries: Optional[list[Boundaries]] = PrivateAttr(default=None)
-    _registry: Optional[HoleRegistry] = PrivateAttr(default=None)
+    _boundaries: list[Boundaries] | None = PrivateAttr(default=None)
+    _registry: HoleRegistry | None = PrivateAttr(default=None)
 
     @field_validator("holes")
     @classmethod
@@ -543,7 +543,7 @@ class TimezoneData(BaseModel):
         return self.hole_store.polynrs_of_holes
 
     @property
-    def original_polygons(self) -> Optional[list[np.ndarray]]:
+    def original_polygons(self) -> list[np.ndarray] | None:
         return self.polygon_store.original_polygons
 
     @property

--- a/scripts/timezone_data.py
+++ b/scripts/timezone_data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Tuple
+from typing import Any, Optional, Set, Tuple
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -130,7 +130,7 @@ class PolygonCollection(BaseModel):
     lengths: LengthList
     original_polygons: Optional[list[np.ndarray]] = None
     _boundaries: Optional[list[Boundaries]] = PrivateAttr(default=None)
-    _vertex_hex_cache: Dict[int, Dict[int, Set[int]]] = PrivateAttr(
+    _vertex_hex_cache: dict[int, dict[int, Set[int]]] = PrivateAttr(
         default_factory=dict
     )
 
@@ -264,7 +264,7 @@ class HoleCollection(BaseModel):
 
 @dataclass
 class HexCache:
-    cache: Dict[int, Hex] = field(default_factory=dict)
+    cache: dict[int, Hex] = field(default_factory=dict)
 
     def get(self, hex_id: int, data: "TimezoneData") -> Hex:
         try:

--- a/scripts/timezone_data.py
+++ b/scripts/timezone_data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional, Set
+from typing import Any, Optional
 
 import h3.api.numpy_int as h3
 import numpy as np
@@ -130,7 +130,7 @@ class PolygonCollection(BaseModel):
     lengths: LengthList
     original_polygons: Optional[list[np.ndarray]] = None
     _boundaries: Optional[list[Boundaries]] = PrivateAttr(default=None)
-    _vertex_hex_cache: dict[int, dict[int, Set[int]]] = PrivateAttr(
+    _vertex_hex_cache: dict[int, dict[int, set[int]]] = PrivateAttr(
         default_factory=dict
     )
 
@@ -168,7 +168,7 @@ class PolygonCollection(BaseModel):
             self._boundaries = compile_bboxes(self.polygons)
         return self._boundaries
 
-    def polygon_vertex_hexes(self, poly_nr: int, res: int) -> Set[int]:
+    def polygon_vertex_hexes(self, poly_nr: int, res: int) -> set[int]:
         res_cache = self._vertex_hex_cache.setdefault(res, {})
         try:
             return res_cache[poly_nr]
@@ -576,7 +576,7 @@ class TimezoneData(BaseModel):
     def get_hex(self, hex_id: int) -> Hex:
         return self.hex_cache.get(hex_id, self)
 
-    def polygon_vertex_hexes(self, poly_nr: int, res: int) -> Set[int]:
+    def polygon_vertex_hexes(self, poly_nr: int, res: int) -> set[int]:
         return self.polygon_store.polygon_vertex_hexes(poly_nr, res)
 
     @property

--- a/tests/auxiliaries.py
+++ b/tests/auxiliaries.py
@@ -1,4 +1,3 @@
-from ast import List
 from collections.abc import Iterable
 import fnmatch
 import os
@@ -234,7 +233,7 @@ def ocean2land(test_locations):
         yield lat, lng, description, expected
 
 
-def check_geometry(geometry_obj: List):
+def check_geometry(geometry_obj: list):
     coords = geometry_obj[0][0]
     assert len(coords) == 2, (
         "the polygon does not consist of two latitude longitude lists"
@@ -248,7 +247,7 @@ def check_geometry(geometry_obj: List):
     )
 
 
-def check_pairwise_geometry(geometry_obj: List):
+def check_pairwise_geometry(geometry_obj: list):
     # list of all coord pairs of the first polygon
     cord_pairs = geometry_obj[0][0]
     assert len(cord_pairs) > 2, "a polygon must consist of more than 2 coordinates"

--- a/tests/auxiliaries.py
+++ b/tests/auxiliaries.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import timeit
 from math import log10
-from typing import Callable, Iterator, Tuple, Union
+from typing import Callable, Iterator, Union
 
 import numpy as np
 
@@ -316,7 +316,7 @@ def time_preprocess(time):
     return str(round(time, digits_to_print)) + "s"
 
 
-def get_rnd_query_pt() -> Tuple[float, float]:
+def get_rnd_query_pt() -> tuple[float, float]:
     lng = random.uniform(-MAX_LNG_VAL, MAX_LNG_VAL)
     lat = random.uniform(-MAX_LAT_VAL, MAX_LAT_VAL)
     return lng, lat
@@ -340,7 +340,7 @@ def convert_inside_polygon_input(lng: float, lat: float):
     return x, y
 
 
-def get_pip_test_input() -> Tuple[int, int, np.ndarray]:
+def get_pip_test_input() -> tuple[int, int, np.ndarray]:
     # one test polygon + one query point
     lng, lat = get_rnd_query_pt()
     x, y = convert_inside_polygon_input(lng, lat)

--- a/tests/auxiliaries.py
+++ b/tests/auxiliaries.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import timeit
 from math import log10
-from typing import Callable, Iterator, Union
+from typing import Callable, Iterator
 
 import numpy as np
 
@@ -130,7 +130,7 @@ def file_path_iterator(
             yield file_path
 
 
-def matches_pattern(path: Path, pattern: Union[str, Pattern, None]) -> bool:
+def matches_pattern(path: Path, pattern: str | Pattern | None) -> bool:
     r"""
     Check if a path matches a given pattern.
 
@@ -192,7 +192,7 @@ def matches_pattern(path: Path, pattern: Union[str, Pattern, None]) -> bool:
 
 def filter_paths(
     paths: Iterator[Path],
-    pattern: Union[str, Pattern, None] = None,
+    pattern: str | Pattern | None = None,
     include_matches: bool = True,
 ) -> Iterator[Path]:
     """

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,5 +1,4 @@
 from importlib.util import find_spec
-from typing import Optional
 
 import numpy as np
 import pytest
@@ -78,7 +77,7 @@ class TestBaseTimezoneFinderClass:
         print(f"in_memory={self.in_memory_mode}")
         print(f"file location={self.bin_file_dir}\n")
 
-    def check_timezone_at_results(self, lng, lat, expected: Optional[str] = ""):
+    def check_timezone_at_results(self, lng, lat, expected: str | None = ""):
         # at the edges of the coordinate system the algorithms should still be well defined!
 
         print(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ that its core functionality works properly.
 import shutil
 import sys
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Tuple
 
 import pytest
 
@@ -64,7 +64,7 @@ def venv_bins(tmp_path_factory) -> Tuple[str, str]:
 
 
 @pytest.fixture(scope="session")
-def package_paths() -> Dict[str, Path]:
+def package_paths() -> dict[str, Path]:
     """Build artifacts once and return all package paths."""
     dist_dir = PROJECT_ROOT / "dist"
     if dist_dir.exists():
@@ -81,7 +81,7 @@ def package_paths() -> Dict[str, Path]:
 
 @pytest.mark.parametrize("package_key", ["wheel", "sdist", "source"])
 def test_install_from_artifacts(
-    package_key: str, package_paths: Dict[str, Path], venv_bins: Tuple[str, str]
+    package_key: str, package_paths: dict[str, Path], venv_bins: Tuple[str, str]
 ) -> None:
     python_bin, pip_bin = venv_bins
     package_path = package_paths[package_key]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,6 @@ that its core functionality works properly.
 import shutil
 import sys
 from pathlib import Path
-from typing import Tuple
 
 import pytest
 
@@ -35,7 +34,7 @@ def run_timezonefinder_test(python_bin: str) -> None:
     run_command([python_bin, "-c", code])
 
 
-def setup_venv(tempdir: str, upgrade_pip: bool = False) -> Tuple[str, str]:
+def setup_venv(tempdir: str, upgrade_pip: bool = False) -> tuple[str, str]:
     """Set up a virtual environment and return paths to python and pip binaries."""
     venv_dir = Path(tempdir) / "venv"
     run_command([sys.executable, "-m", "venv", str(venv_dir)])
@@ -57,7 +56,7 @@ def reinstall_and_test(package_path: Path, python_bin: str, pip_bin: str) -> Non
 
 
 @pytest.fixture(scope="session")
-def venv_bins(tmp_path_factory) -> Tuple[str, str]:
+def venv_bins(tmp_path_factory) -> tuple[str, str]:
     """Create a single virtual environment reused across package install checks."""
     tempdir = tmp_path_factory.mktemp("integration-venv")
     return setup_venv(str(tempdir), upgrade_pip=False)
@@ -81,7 +80,7 @@ def package_paths() -> dict[str, Path]:
 
 @pytest.mark.parametrize("package_key", ["wheel", "sdist", "source"])
 def test_install_from_artifacts(
-    package_key: str, package_paths: dict[str, Path], venv_bins: Tuple[str, str]
+    package_key: str, package_paths: dict[str, Path], venv_bins: tuple[str, str]
 ) -> None:
     python_bin, pip_bin = venv_bins
     package_path = package_paths[package_key]

--- a/tests/test_package_contents.py
+++ b/tests/test_package_contents.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import tarfile
 import tempfile
 import zipfile
-from typing import Iterator, Set
+from typing import Iterator
 
 import pytest
 from tests.auxiliaries import (
@@ -119,7 +119,7 @@ WHEEL_EXCEPTION_PATTERNS = {
 }
 
 
-def load_gitignore_patterns() -> Set[str]:
+def load_gitignore_patterns() -> set[str]:
     """
     Load patterns from a .gitignore file.
 

--- a/tests/test_package_contents.py
+++ b/tests/test_package_contents.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import tarfile
 import tempfile
 import zipfile
-from typing import Iterator, List, Set
+from typing import Iterator, Set
 
 import pytest
 from tests.auxiliaries import (
@@ -189,7 +189,7 @@ def iter_expected_distribution_files() -> Iterator[Path]:
     return any_filter_paths(all_files, ESSENTIAL_SOURCE_PATTERNS, include_matches=True)
 
 
-def extract_archive(archive_path: Path) -> List[Path]:
+def extract_archive(archive_path: Path) -> list[Path]:
     """Extract the tar.gz archive in the given path and return a list of the contained files."""
     with tarfile.open(archive_path, "r:gz") as tar:
         # Get the name of the top-level directory in the archive
@@ -220,7 +220,7 @@ def extract_archive(archive_path: Path) -> List[Path]:
     return file_list
 
 
-def extract_wheel(wheel_path: Path) -> List[Path]:
+def extract_wheel(wheel_path: Path) -> list[Path]:
     """Extract the wheel (.whl) file in the given path and return a list of the contained files."""
     with zipfile.ZipFile(wheel_path) as wheel:
         # List all files in the wheel

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -194,7 +194,7 @@ def test_clang_extension_loaded():
     "test_case",
     POINT_IN_POLYGON_TESTCASES,
 )
-def test_inside_polygon(inside_poly_func: Callable, test_case: Tuple):
+def test_inside_polygon(inside_poly_func: Callable, test_case: tuple):
     # print(f"\ntesting function {inside_poly_func.__name__}")
 
     # test for overflow:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple
+from typing import Callable
 
 import numpy as np
 import pytest

--- a/timezonefinder/build.py
+++ b/timezonefinder/build.py
@@ -8,7 +8,6 @@ https://github.com/libmbd/libmbd/blob/master/build.py
 
 import pathlib
 import re
-from typing import Optional
 import warnings
 
 import cffi
@@ -20,7 +19,7 @@ EXTENSION_PATH = pathlib.Path("timezonefinder") / "inside_poly_extension"
 h_file_path = EXTENSION_PATH / H_FILE_NAME
 c_file_path = EXTENSION_PATH / C_FILE_NAME
 
-ffibuilder: Optional[cffi.FFI] = None
+ffibuilder: cffi.FFI | None = None
 try:
     ffibuilder = cffi.FFI()
 except Exception as exc:

--- a/timezonefinder/configs.py
+++ b/timezonefinder/configs.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 
@@ -39,7 +39,7 @@ assert MAX_INT_VAL < MAX_ALLOWED_COORD_VAL
 #  the functions due to caching!
 
 # Type alias for flexibility with integer types (pure int or numpy integer scalars)
-IntegerLike = Union[int, np.integer]
+IntegerLike = int | np.integer
 
 # hexagon id to list of polygon ids
 ShortcutMapping = dict[int, np.ndarray]

--- a/timezonefinder/configs.py
+++ b/timezonefinder/configs.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Tuple, Union
+from typing import Any, Union
 
 import numpy as np
 
@@ -43,7 +43,7 @@ IntegerLike = Union[int, np.integer]
 
 # hexagon id to list of polygon ids
 ShortcutMapping = dict[int, np.ndarray]
-CoordPairs = list[Tuple[float, float]]
+CoordPairs = list[tuple[float, float]]
 CoordLists = list[list[float]]
 IntLists = list[list[int]]
 
@@ -79,7 +79,7 @@ def zone_id_dtype_to_string(dtype: np.dtype) -> str:
     return dtype.newbyteorder("<").str
 
 
-def available_zone_id_dtype_names() -> Tuple[str, ...]:
+def available_zone_id_dtype_names() -> tuple[str, ...]:
     """Return the supported zone id dtype names."""
 
     return tuple(sorted(_ZONE_ID_DTYPE_ALIASES))

--- a/timezonefinder/configs.py
+++ b/timezonefinder/configs.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Tuple, Union
 
 import numpy as np
 
@@ -42,7 +42,7 @@ assert MAX_INT_VAL < MAX_ALLOWED_COORD_VAL
 IntegerLike = Union[int, np.integer]
 
 # hexagon id to list of polygon ids
-ShortcutMapping = Dict[int, np.ndarray]
+ShortcutMapping = dict[int, np.ndarray]
 CoordPairs = list[Tuple[float, float]]
 CoordLists = list[list[float]]
 IntLists = list[list[int]]
@@ -50,7 +50,7 @@ IntLists = list[list[int]]
 
 # zone id storage settings ---------------------------------------------------
 
-_ZONE_ID_DTYPE_ALIASES: Dict[str, "np.dtype[Any]"] = {
+_ZONE_ID_DTYPE_ALIASES: dict[str, "np.dtype[Any]"] = {
     "uint8": np.dtype("<u1"),
     "uint16": np.dtype("<u2"),
 }

--- a/timezonefinder/configs.py
+++ b/timezonefinder/configs.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import numpy as np
 
@@ -43,9 +43,9 @@ IntegerLike = Union[int, np.integer]
 
 # hexagon id to list of polygon ids
 ShortcutMapping = Dict[int, np.ndarray]
-CoordPairs = List[Tuple[float, float]]
-CoordLists = List[List[float]]
-IntLists = List[List[int]]
+CoordPairs = list[Tuple[float, float]]
+CoordLists = list[list[float]]
+IntLists = list[list[int]]
 
 
 # zone id storage settings ---------------------------------------------------

--- a/timezonefinder/configs.py
+++ b/timezonefinder/configs.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias
 
 import numpy as np
 
@@ -39,13 +39,13 @@ assert MAX_INT_VAL < MAX_ALLOWED_COORD_VAL
 #  the functions due to caching!
 
 # Type alias for flexibility with integer types (pure int or numpy integer scalars)
-IntegerLike = int | np.integer
+IntegerLike: TypeAlias = int | np.integer
 
 # hexagon id to list of polygon ids
-ShortcutMapping = dict[int, np.ndarray]
-CoordPairs = list[tuple[float, float]]
-CoordLists = list[list[float]]
-IntLists = list[list[int]]
+ShortcutMapping: TypeAlias = dict[int, np.ndarray]
+CoordPairs: TypeAlias = list[tuple[float, float]]
+CoordLists: TypeAlias = list[list[float]]
+IntLists: TypeAlias = list[list[int]]
 
 
 # zone id storage settings ---------------------------------------------------

--- a/timezonefinder/coord_accessors.py
+++ b/timezonefinder/coord_accessors.py
@@ -8,7 +8,6 @@ either directly from file or from preloaded memory.
 from abc import ABC, abstractmethod
 import mmap
 from pathlib import Path
-from typing import Dict
 
 import numpy as np
 
@@ -134,7 +133,7 @@ class MemoryCoordAccessor(AbstractCoordAccessor):
         num_polygons = polygon_collection.PolygonsLength()
 
         # Preload all polygons
-        self.polygons: Dict[int, np.ndarray] = {}
+        self.polygons: dict[int, np.ndarray] = {}
         for idx in range(num_polygons):
             self.polygons[idx] = read_polygon_array_from_binary(polygon_collection, idx)
 

--- a/timezonefinder/flatbuf/io/hybrid_shortcuts.py
+++ b/timezonefinder/flatbuf/io/hybrid_shortcuts.py
@@ -1,7 +1,7 @@
 """Utilities for working with optimized hybrid shortcut FlatBuffer data."""
 
 from pathlib import Path
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Union
 from dataclasses import dataclass
 
 import flatbuffers
@@ -147,7 +147,7 @@ def _validate_zone_id_dtype(zone_id_dtype: np.dtype) -> np.dtype:
 
 
 def write_hybrid_shortcuts_flatbuffers(
-    hybrid_mapping: Dict[int, Union[int, list[int]]],
+    hybrid_mapping: dict[int, Union[int, list[int]]],
     zone_id_dtype: np.dtype,
     output_file: Path,
 ) -> None:
@@ -168,7 +168,7 @@ def write_hybrid_shortcuts_flatbuffers(
 
 
 def _write_hybrid_shortcuts_generic(
-    hybrid_mapping: Dict[int, Union[int, list[int]]],
+    hybrid_mapping: dict[int, Union[int, list[int]]],
     zone_id_dtype: np.dtype,
     output_file: Path,
 ) -> None:
@@ -224,7 +224,7 @@ def _write_hybrid_shortcuts_generic(
 
 
 def _write_hybrid_shortcuts_with_schema(
-    hybrid_mapping: Dict[int, Union[int, list[int]]],
+    hybrid_mapping: dict[int, Union[int, list[int]]],
     output_file: Path,
     schema: SchemaImports,
 ) -> None:
@@ -294,7 +294,7 @@ def _write_hybrid_shortcuts_with_schema(
 
 def read_hybrid_shortcuts_binary(
     file_path: Path,
-) -> Dict[int, Union[int, np.ndarray]]:
+) -> dict[int, Union[int, np.ndarray]]:
     """
     Read hybrid shortcut mapping from an optimized FlatBuffer binary file.
 
@@ -334,7 +334,7 @@ def read_hybrid_shortcuts_binary(
 
 def _read_hybrid_shortcuts_with_schema(
     file_path: Path, schema: ReadSchemaImports
-) -> Dict[int, Union[int, np.ndarray]]:
+) -> dict[int, Union[int, np.ndarray]]:
     """Read hybrid shortcuts using the provided schema imports."""
     with open(file_path, "rb") as f:
         buf = f.read()
@@ -342,7 +342,7 @@ def _read_hybrid_shortcuts_with_schema(
     # mypy: GetRootAs is a class method on FlatBuffers classes
     collection = schema.collection.GetRootAs(buf, 0)  # type: ignore
 
-    hybrid_mapping: Dict[int, Union[int, np.ndarray]] = {}
+    hybrid_mapping: dict[int, Union[int, np.ndarray]] = {}
     for i in range(collection.EntriesLength()):
         entry = collection.Entries(i)
         hex_id = entry.HexId()

--- a/timezonefinder/flatbuf/io/hybrid_shortcuts.py
+++ b/timezonefinder/flatbuf/io/hybrid_shortcuts.py
@@ -1,7 +1,7 @@
 """Utilities for working with optimized hybrid shortcut FlatBuffer data."""
 
 from pathlib import Path
-from typing import Any, Callable, Union
+from typing import Any, Callable
 from dataclasses import dataclass
 
 import flatbuffers
@@ -147,7 +147,7 @@ def _validate_zone_id_dtype(zone_id_dtype: np.dtype) -> np.dtype:
 
 
 def write_hybrid_shortcuts_flatbuffers(
-    hybrid_mapping: dict[int, Union[int, list[int]]],
+    hybrid_mapping: dict[int, int | list[int]],
     zone_id_dtype: np.dtype,
     output_file: Path,
 ) -> None:
@@ -168,7 +168,7 @@ def write_hybrid_shortcuts_flatbuffers(
 
 
 def _write_hybrid_shortcuts_generic(
-    hybrid_mapping: dict[int, Union[int, list[int]]],
+    hybrid_mapping: dict[int, int | list[int]],
     zone_id_dtype: np.dtype,
     output_file: Path,
 ) -> None:
@@ -224,7 +224,7 @@ def _write_hybrid_shortcuts_generic(
 
 
 def _write_hybrid_shortcuts_with_schema(
-    hybrid_mapping: dict[int, Union[int, list[int]]],
+    hybrid_mapping: dict[int, int | list[int]],
     output_file: Path,
     schema: SchemaImports,
 ) -> None:
@@ -294,7 +294,7 @@ def _write_hybrid_shortcuts_with_schema(
 
 def read_hybrid_shortcuts_binary(
     file_path: Path,
-) -> dict[int, Union[int, np.ndarray]]:
+) -> dict[int, int | np.ndarray]:
     """
     Read hybrid shortcut mapping from an optimized FlatBuffer binary file.
 
@@ -334,7 +334,7 @@ def read_hybrid_shortcuts_binary(
 
 def _read_hybrid_shortcuts_with_schema(
     file_path: Path, schema: ReadSchemaImports
-) -> dict[int, Union[int, np.ndarray]]:
+) -> dict[int, int | np.ndarray]:
     """Read hybrid shortcuts using the provided schema imports."""
     with open(file_path, "rb") as f:
         buf = f.read()
@@ -342,7 +342,7 @@ def _read_hybrid_shortcuts_with_schema(
     # mypy: GetRootAs is a class method on FlatBuffers classes
     collection = schema.collection.GetRootAs(buf, 0)  # type: ignore
 
-    hybrid_mapping: dict[int, Union[int, np.ndarray]] = {}
+    hybrid_mapping: dict[int, int | np.ndarray] = {}
     for i in range(collection.EntriesLength()):
         entry = collection.Entries(i)
         hex_id = entry.HexId()

--- a/timezonefinder/flatbuf/io/hybrid_shortcuts.py
+++ b/timezonefinder/flatbuf/io/hybrid_shortcuts.py
@@ -1,7 +1,7 @@
 """Utilities for working with optimized hybrid shortcut FlatBuffer data."""
 
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, Union
 from dataclasses import dataclass
 
 import flatbuffers
@@ -147,7 +147,7 @@ def _validate_zone_id_dtype(zone_id_dtype: np.dtype) -> np.dtype:
 
 
 def write_hybrid_shortcuts_flatbuffers(
-    hybrid_mapping: Dict[int, Union[int, List[int]]],
+    hybrid_mapping: Dict[int, Union[int, list[int]]],
     zone_id_dtype: np.dtype,
     output_file: Path,
 ) -> None:
@@ -157,7 +157,7 @@ def write_hybrid_shortcuts_flatbuffers(
     Args:
         hybrid_mapping: Dictionary mapping H3 hexagon IDs to either:
                        - int: unique zone ID (when all polygons share same zone)
-                       - List[int]: list of polygon IDs (when multiple zones)
+                       - list[int]: list of polygon IDs (when multiple zones)
         zone_id_dtype: numpy dtype for zone IDs (uint8 or uint16)
         output_file: Path to save the FlatBuffer file
     """
@@ -168,7 +168,7 @@ def write_hybrid_shortcuts_flatbuffers(
 
 
 def _write_hybrid_shortcuts_generic(
-    hybrid_mapping: Dict[int, Union[int, List[int]]],
+    hybrid_mapping: Dict[int, Union[int, list[int]]],
     zone_id_dtype: np.dtype,
     output_file: Path,
 ) -> None:
@@ -224,7 +224,7 @@ def _write_hybrid_shortcuts_generic(
 
 
 def _write_hybrid_shortcuts_with_schema(
-    hybrid_mapping: Dict[int, Union[int, List[int]]],
+    hybrid_mapping: Dict[int, Union[int, list[int]]],
     output_file: Path,
     schema: SchemaImports,
 ) -> None:

--- a/timezonefinder/flatbuf/io/polygons.py
+++ b/timezonefinder/flatbuf/io/polygons.py
@@ -2,7 +2,6 @@ import flatbuffers
 import mmap
 import numpy as np
 from pathlib import Path
-from typing import Union
 
 from timezonefinder.configs import DEFAULT_DATA_DIR
 from timezonefinder.flatbuf.generated.polygons.Polygon import (
@@ -104,7 +103,7 @@ def write_polygon_collection_flatbuffer(
         f.write(buf)
 
 
-def get_polygon_collection(buf: Union[bytes, mmap.mmap]) -> PolygonCollection:
+def get_polygon_collection(buf: bytes | mmap.mmap) -> PolygonCollection:
     """Load a PolygonCollection from a file path.
 
     Args:

--- a/timezonefinder/flatbuf/io/polygons.py
+++ b/timezonefinder/flatbuf/io/polygons.py
@@ -2,7 +2,7 @@ import flatbuffers
 import mmap
 import numpy as np
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 from timezonefinder.configs import DEFAULT_DATA_DIR
 from timezonefinder.flatbuf.generated.polygons.Polygon import (
@@ -52,7 +52,7 @@ def get_coordinate_path(data_dir: Path = DEFAULT_DATA_DIR) -> Path:
 
 
 def write_polygon_collection_flatbuffer(
-    file_path: Path, polygons: List[np.ndarray]
+    file_path: Path, polygons: list[np.ndarray]
 ) -> None:
     """Write a collection of polygons to a flatbuffer file using a single coordinate vector.
 

--- a/timezonefinder/global_functions.py
+++ b/timezonefinder/global_functions.py
@@ -6,7 +6,6 @@ TimezoneFinder in a multi-threaded environment, create separate TimezoneFinder i
 for each thread.
 """
 
-
 from timezonefinder.timezonefinder import TimezoneFinder
 from timezonefinder.configs import CoordPairs, CoordLists
 

--- a/timezonefinder/global_functions.py
+++ b/timezonefinder/global_functions.py
@@ -6,7 +6,6 @@ TimezoneFinder in a multi-threaded environment, create separate TimezoneFinder i
 for each thread.
 """
 
-from typing import Optional
 
 from timezonefinder.timezonefinder import TimezoneFinder
 from timezonefinder.configs import CoordPairs, CoordLists
@@ -31,7 +30,7 @@ def _get_tf_instance() -> TimezoneFinder:
     return TF_INSTANCE
 
 
-def timezone_at(*, lng: float, lat: float) -> Optional[str]:
+def timezone_at(*, lng: float, lat: float) -> str | None:
     """
     Looks up in which timezone the given coordinate is included in.
     Uses the global TimezoneFinder instance.
@@ -46,7 +45,7 @@ def timezone_at(*, lng: float, lat: float) -> Optional[str]:
     return _get_tf_instance().timezone_at(lng=lng, lat=lat)
 
 
-def timezone_at_land(*, lng: float, lat: float) -> Optional[str]:
+def timezone_at_land(*, lng: float, lat: float) -> str | None:
     """
     Computes in which land timezone a point is included in.
     Uses the global TimezoneFinder instance.
@@ -62,7 +61,7 @@ def timezone_at_land(*, lng: float, lat: float) -> Optional[str]:
     return _get_tf_instance().timezone_at_land(lng=lng, lat=lat)
 
 
-def unique_timezone_at(*, lng: float, lat: float) -> Optional[str]:
+def unique_timezone_at(*, lng: float, lat: float) -> str | None:
     """
     Returns the name of a unique zone within the corresponding shortcut.
     Uses the global TimezoneFinder instance.
@@ -77,7 +76,7 @@ def unique_timezone_at(*, lng: float, lat: float) -> Optional[str]:
     return _get_tf_instance().unique_timezone_at(lng=lng, lat=lat)
 
 
-def certain_timezone_at(*, lng: float, lat: float) -> Optional[str]:
+def certain_timezone_at(*, lng: float, lat: float) -> str | None:
     """
     Checks in which timezone polygon the point is certainly included in.
     Uses the global TimezoneFinder instance.
@@ -100,8 +99,8 @@ def certain_timezone_at(*, lng: float, lat: float) -> Optional[str]:
 
 
 def get_geometry(
-    tz_name: Optional[str] = "",
-    tz_id: Optional[int] = 0,
+    tz_name: str | None = "",
+    tz_id: int | None = 0,
     use_id: bool = False,
     coords_as_pairs: bool = False,
 ) -> list[list[CoordPairs | CoordLists]]:

--- a/timezonefinder/global_functions.py
+++ b/timezonefinder/global_functions.py
@@ -6,7 +6,7 @@ TimezoneFinder in a multi-threaded environment, create separate TimezoneFinder i
 for each thread.
 """
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from timezonefinder.timezonefinder import TimezoneFinder
 from timezonefinder.configs import CoordPairs, CoordLists
@@ -104,7 +104,7 @@ def get_geometry(
     tz_id: Optional[int] = 0,
     use_id: bool = False,
     coords_as_pairs: bool = False,
-) -> List[List[Union[CoordPairs, CoordLists]]]:
+) -> list[list[Union[CoordPairs, CoordLists]]]:
     """
     Retrieves the geometry of a timezone polygon.
     Uses the global TimezoneFinder instance.

--- a/timezonefinder/global_functions.py
+++ b/timezonefinder/global_functions.py
@@ -6,7 +6,7 @@ TimezoneFinder in a multi-threaded environment, create separate TimezoneFinder i
 for each thread.
 """
 
-from typing import Optional, Union
+from typing import Optional
 
 from timezonefinder.timezonefinder import TimezoneFinder
 from timezonefinder.configs import CoordPairs, CoordLists
@@ -104,7 +104,7 @@ def get_geometry(
     tz_id: Optional[int] = 0,
     use_id: bool = False,
     coords_as_pairs: bool = False,
-) -> list[list[Union[CoordPairs, CoordLists]]]:
+) -> list[list[CoordPairs | CoordLists]]:
     """
     Retrieves the geometry of a timezone polygon.
     Uses the global TimezoneFinder instance.

--- a/timezonefinder/polygon_array.py
+++ b/timezonefinder/polygon_array.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Iterable, Union
+from typing import Iterable
 
 import numpy as np
 
@@ -28,7 +28,7 @@ class PolygonArray:
 
     def __init__(
         self,
-        data_location: Union[str, Path],
+        data_location: str | Path,
         in_memory: bool = False,
     ):
         """

--- a/timezonefinder/timezonefinder.py
+++ b/timezonefinder/timezonefinder.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Dict, Iterable, Optional, Tuple, Union
+from typing import Iterable, Optional, Tuple, Union
 import numpy as np
 from h3.api import numpy_int as h3
 
@@ -47,7 +47,7 @@ class AbstractTimezoneFinder(ABC):
     ]
 
     zone_ids: np.ndarray
-    shortcut_mapping: Dict[int, Union[int, np.ndarray]]
+    shortcut_mapping: dict[int, Union[int, np.ndarray]]
     """
     List of attribute names that store opened binary data files.
     """
@@ -355,7 +355,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
         except Exception:
             pass
 
-    def _load_hole_registry(self) -> Dict[int, Tuple[int, int]]:
+    def _load_hole_registry(self) -> dict[int, Tuple[int, int]]:
         """
         Load and convert the hole registry from JSON file, converting keys to int.
         """

--- a/timezonefinder/timezonefinder.py
+++ b/timezonefinder/timezonefinder.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable, Optional, Union
 import numpy as np
 from h3.api import numpy_int as h3
 
@@ -355,7 +355,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
         except Exception:
             pass
 
-    def _load_hole_registry(self) -> dict[int, Tuple[int, int]]:
+    def _load_hole_registry(self) -> dict[int, tuple[int, int]]:
         """
         Load and convert the hole registry from JSON file, converting keys to int.
         """

--- a/timezonefinder/timezonefinder.py
+++ b/timezonefinder/timezonefinder.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import Dict, Iterable, Optional, Tuple, Union
 import numpy as np
 from h3.api import numpy_int as h3
 
@@ -408,7 +408,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
 
     def get_polygon(
         self, boundary_id: IntegerLike, coords_as_pairs: bool = False
-    ) -> List[Union[CoordPairs, CoordLists]]:
+    ) -> list[Union[CoordPairs, CoordLists]]:
         """
         Get the polygon coordinates of a given boundary polygon including its holes.
 
@@ -437,7 +437,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
         tz_id: Optional[int] = 0,
         use_id: bool = False,
         coords_as_pairs: bool = False,
-    ) -> List[List[Union[CoordPairs, CoordLists]]]:
+    ) -> list[list[Union[CoordPairs, CoordLists]]]:
         """retrieves the geometry of a timezone: multiple boundary polygons with holes
 
         :param tz_name: one of the names in ``timezone_names.json`` or ``self.timezone_names``

--- a/timezonefinder/timezonefinder.py
+++ b/timezonefinder/timezonefinder.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable
 import numpy as np
 from h3.api import numpy_int as h3
 
@@ -54,7 +54,7 @@ class AbstractTimezoneFinder(ABC):
 
     def __init__(
         self,
-        bin_file_location: Optional[str | Path] = None,
+        bin_file_location: str | Path | None = None,
         in_memory: bool = False,
     ):
         """
@@ -189,7 +189,7 @@ class AbstractTimezoneFinder(ABC):
             yield from shortcut_value
 
     @abstractmethod
-    def timezone_at(self, *, lng: float, lat: float) -> Optional[str]:
+    def timezone_at(self, *, lng: float, lat: float) -> str | None:
         """looks up in which timezone the given coordinate is included in
 
         :param lng: longitude of the point in degree (-180.0 to 180.0)
@@ -198,7 +198,7 @@ class AbstractTimezoneFinder(ABC):
         """
         ...
 
-    def timezone_at_land(self, *, lng: float, lat: float) -> Optional[str]:
+    def timezone_at_land(self, *, lng: float, lat: float) -> str | None:
         """computes in which land timezone a point is included in
 
         Especially for large polygons it is expensive to check if a point is really included.
@@ -215,7 +215,7 @@ class AbstractTimezoneFinder(ABC):
             return None
         return tz_name
 
-    def unique_timezone_at(self, *, lng: float, lat: float) -> Optional[str]:
+    def unique_timezone_at(self, *, lng: float, lat: float) -> str | None:
         """returns the name of a unique zone within the corresponding shortcut
 
         :param lng: longitude of the point in degree (-180.0 to 180.0)
@@ -272,12 +272,12 @@ class TimezoneFinderL(AbstractTimezoneFinder):
 
     def __init__(
         self,
-        bin_file_location: Optional[str | Path] = None,
+        bin_file_location: str | Path | None = None,
         in_memory: bool = False,
     ):
         super().__init__(bin_file_location, in_memory)
 
-    def timezone_at(self, *, lng: float, lat: float) -> Optional[str]:
+    def timezone_at(self, *, lng: float, lat: float) -> str | None:
         """instantly returns the name of the most common zone within the corresponding shortcut
 
         Note: 'most common' in this context means that the boundary polygons with the most coordinates in sum
@@ -333,7 +333,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
 
     def __init__(
         self,
-        bin_file_location: Optional[str | Path] = None,
+        bin_file_location: str | Path | None = None,
         in_memory: bool = False,
     ):
         super().__init__(bin_file_location, in_memory)
@@ -433,8 +433,8 @@ class TimezoneFinder(AbstractTimezoneFinder):
 
     def get_geometry(
         self,
-        tz_name: Optional[str] = "",
-        tz_id: Optional[int] = 0,
+        tz_name: str | None = "",
+        tz_id: int | None = 0,
         use_id: bool = False,
         coords_as_pairs: bool = False,
     ) -> list[list[CoordPairs | CoordLists]]:
@@ -496,7 +496,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
 
         return self.boundaries.pip(boundary_id, x, y)
 
-    def timezone_at(self, *, lng: float, lat: float) -> Optional[str]:
+    def timezone_at(self, *, lng: float, lat: float) -> str | None:
         """
         Find the timezone for a given point using hybrid shortcuts, considering both land and ocean timezones.
 
@@ -559,7 +559,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
         zone_id = zone_ids[-1]
         return self.zone_name_from_id(int(zone_id))
 
-    def certain_timezone_at(self, *, lng: float, lat: float) -> Optional[str]:
+    def certain_timezone_at(self, *, lng: float, lat: float) -> str | None:
         """checks in which timezone polygon the point is certainly included in using hybrid shortcuts
 
         .. note:: this is only meaningful when you have compiled your own timezone data

--- a/timezonefinder/timezonefinder.py
+++ b/timezonefinder/timezonefinder.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional
 import numpy as np
 from h3.api import numpy_int as h3
 
@@ -47,14 +47,14 @@ class AbstractTimezoneFinder(ABC):
     ]
 
     zone_ids: np.ndarray
-    shortcut_mapping: dict[int, Union[int, np.ndarray]]
+    shortcut_mapping: dict[int, int | np.ndarray]
     """
     List of attribute names that store opened binary data files.
     """
 
     def __init__(
         self,
-        bin_file_location: Optional[Union[str, Path]] = None,
+        bin_file_location: Optional[str | Path] = None,
         in_memory: bool = False,
     ):
         """
@@ -272,7 +272,7 @@ class TimezoneFinderL(AbstractTimezoneFinder):
 
     def __init__(
         self,
-        bin_file_location: Optional[Union[str, Path]] = None,
+        bin_file_location: Optional[str | Path] = None,
         in_memory: bool = False,
     ):
         super().__init__(bin_file_location, in_memory)
@@ -333,7 +333,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
 
     def __init__(
         self,
-        bin_file_location: Optional[Union[str, Path]] = None,
+        bin_file_location: Optional[str | Path] = None,
         in_memory: bool = False,
     ):
         super().__init__(bin_file_location, in_memory)
@@ -408,7 +408,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
 
     def get_polygon(
         self, boundary_id: IntegerLike, coords_as_pairs: bool = False
-    ) -> list[Union[CoordPairs, CoordLists]]:
+    ) -> list[CoordPairs | CoordLists]:
         """
         Get the polygon coordinates of a given boundary polygon including its holes.
 
@@ -437,7 +437,7 @@ class TimezoneFinder(AbstractTimezoneFinder):
         tz_id: Optional[int] = 0,
         use_id: bool = False,
         coords_as_pairs: bool = False,
-    ) -> list[list[Union[CoordPairs, CoordLists]]]:
+    ) -> list[list[CoordPairs | CoordLists]]:
         """retrieves the geometry of a timezone: multiple boundary polygons with holes
 
         :param tz_name: one of the names in ``timezone_names.json`` or ``self.timezone_names``

--- a/timezonefinder/utils.py
+++ b/timezonefinder/utils.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 import re
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 import numpy as np
 
@@ -45,7 +45,7 @@ def validate_lng(lng: float) -> None:
         raise ValueError(f"The given longitude {lng} is out of bounds")
 
 
-def validate_coordinates(lng: float, lat: float) -> Tuple[float, float]:
+def validate_coordinates(lng: float, lat: float) -> tuple[float, float]:
     lng, lat = float(lng), float(lat)
     validate_lng(lng)
     validate_lat(lat)

--- a/timezonefinder/utils_clang.py
+++ b/timezonefinder/utils_clang.py
@@ -1,10 +1,10 @@
-from typing import Final, Optional
+from typing import Final
 
 import cffi
 
 import numpy as np
 
-ffi: Optional[cffi.FFI] = None
+ffi: cffi.FFI | None = None
 try:
     # Note: IDE might complain as this import comes from a cffi C extension
     from timezonefinder import inside_polygon_ext  # type: ignore

--- a/timezonefinder/zone_names.py
+++ b/timezonefinder/zone_names.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List
 
 from timezonefinder.configs import DEFAULT_DATA_DIR
 
@@ -10,7 +9,7 @@ def get_zone_names_path(output_path: Path = DEFAULT_DATA_DIR) -> Path:
 
 
 def write_zone_names(
-    zone_names: List[str], output_path: Path = DEFAULT_DATA_DIR
+    zone_names: list[str], output_path: Path = DEFAULT_DATA_DIR
 ) -> None:
     """
     Write timezone names to a text file.
@@ -25,7 +24,7 @@ def write_zone_names(
         f.write("\n")  # write a newline at the end of the file
 
 
-def read_zone_names(path: Path) -> List[str]:
+def read_zone_names(path: Path) -> list[str]:
     """
     Read timezone names from a text file.
 


### PR DESCRIPTION
This PR updates the repository using typing notation introduced in python 3.10.  Legacy typing module constructs (Dict, List, Set, Tuple) where exchanged for the native syntax (dict, list, set, tuple) and the union operator | is used to  avoid using Optional and Union. In addition to that, TypeAlias is used explicitly on type variables.

Initial investigation was done by reading [python's whatsnew](https://docs.python.org/3/whatsnew/3.10.html) page and an original plan was done with ChatGPT 5.3. The execution of the plan was done using Claude Sonnet 4.5 and this refactoring was checked in detail, changed by change. Prompts can be made available under request. I am available for any question.

Fixes #389