### PR TITLE
test: add hypothesis property tests for coordinate validation (#143)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Internal:
 * added ``DATA_VERSION`` file tracking which timezone-boundary-builder release the packaged data was generated from, written automatically by the data update script after a successful parse. Thanks to `Lucas Hemkemeier <https://github.com/hemkdev>`__ for the PR #429
 * added scheduled GitHub Actions workflow comparing ``DATA_VERSION`` against the latest timezone-boundary-builder release weekly and opening an issue when new boundary data is available (solves issue #273)
 * made the data update script CI-ready and renamed it from ``parse_data.sh`` to ``update_data.sh``: interactive prompts replaced by command line flags (``--dataset=full|same-since-now``, ``--with-oceans``, ``--rm-tmp``) and the changelog entry for data updates is now generated automatically (issue #167)
+* added property-based tests (``hypothesis``) for coordinate validation (solves issue #143)
 
 
 8.2.5 (2026-07-11)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ docs = [
 test=[
     "tox",
     "pytest",
+    "hypothesis>=6",
     # used in example scripts
     "pytz>=2022.7.1",
     # setuptoosl required for integration tests: building sdist and wheel

--- a/tests/test_property_validation.py
+++ b/tests/test_property_validation.py
@@ -5,8 +5,6 @@ Uses ``hypothesis`` to exercise the full finite input space of
 complementing the example-based tests in ``tests/utils_test.py``.
 """
 
-import math
-
 import pytest
 from hypothesis import given, strategies as st
 
@@ -31,10 +29,10 @@ _OUT_OF_RANGE_LAT = st.floats(allow_nan=False, allow_infinity=False).filter(
     lambda x: not (-90.0 <= x <= 90.0)
 )
 
-# NaN values (allow_nan=True; the filter keeps only the NaN draws).
-_NAN = st.floats(allow_nan=True, allow_infinity=False).filter(math.isnan)
-# Infinity values (allow_infinity=True; the filter keeps only the Inf draws).
-_INF = st.floats(allow_nan=False, allow_infinity=True).filter(math.isinf)
+# NaN / Inf are only a few distinct values, so construct them directly instead
+# of generating many floats only to filter most of them away.
+_NAN = st.just(float("nan"))
+_INF = st.sampled_from([float("inf"), float("-inf")])
 
 # Pairs where at least one coordinate is NaN (resp. Inf); the other is valid.
 _NAN_PAIR = st.one_of(

--- a/tests/test_property_validation.py
+++ b/tests/test_property_validation.py
@@ -1,0 +1,109 @@
+"""Property-based tests for coordinate validation functions.
+
+Uses ``hypothesis`` to exercise the full finite input space of
+``validate_coordinates``, ``validate_lat``, and ``validate_lng``,
+complementing the example-based tests in ``tests/utils_test.py``.
+"""
+
+import math
+
+import pytest
+from hypothesis import given, strategies as st
+
+from timezonefinder import utils
+
+
+# Finite in-range coordinates. allow_nan=False and allow_infinity=False are
+# mandatory: otherwise hypothesis would emit NaN/Inf, which are invalid, and
+# the "valid" properties below would fail.
+_VALID_LNG = st.floats(
+    min_value=-180.0, max_value=180.0, allow_nan=False, allow_infinity=False
+)
+_VALID_LAT = st.floats(
+    min_value=-90.0, max_value=90.0, allow_nan=False, allow_infinity=False
+)
+
+# Finite floats strictly outside the valid range (bounds are inclusive).
+_OUT_OF_RANGE_LNG = st.floats(allow_nan=False, allow_infinity=False).filter(
+    lambda x: not (-180.0 <= x <= 180.0)
+)
+_OUT_OF_RANGE_LAT = st.floats(allow_nan=False, allow_infinity=False).filter(
+    lambda x: not (-90.0 <= x <= 90.0)
+)
+
+# NaN values (allow_nan=True; the filter keeps only the NaN draws).
+_NAN = st.floats(allow_nan=True, allow_infinity=False).filter(math.isnan)
+# Infinity values (allow_infinity=True; the filter keeps only the Inf draws).
+_INF = st.floats(allow_nan=False, allow_infinity=True).filter(math.isinf)
+
+# Pairs where at least one coordinate is NaN (resp. Inf); the other is valid.
+_NAN_PAIR = st.one_of(
+    st.tuples(_NAN, _VALID_LAT),
+    st.tuples(_VALID_LNG, _NAN),
+    st.tuples(_NAN, _NAN),
+)
+_INF_PAIR = st.one_of(
+    st.tuples(_INF, _VALID_LAT),
+    st.tuples(_VALID_LNG, _INF),
+    st.tuples(_INF, _INF),
+)
+
+
+@pytest.mark.unit
+@given(lng=_VALID_LNG, lat=_VALID_LAT)
+def test_validate_coordinates_accepts_valid(lng, lat):
+    """Valid finite in-range coordinates pass through unchanged as floats."""
+    result = utils.validate_coordinates(lng=lng, lat=lat)
+    assert result == (lng, lat)
+    assert isinstance(result[0], float)
+    assert isinstance(result[1], float)
+
+
+@pytest.mark.unit
+@given(lng=_OUT_OF_RANGE_LNG, lat=_VALID_LAT)
+def test_validate_coordinates_rejects_out_of_range_lng(lng, lat):
+    """Finite longitude outside [-180, 180] raises ValueError."""
+    with pytest.raises(ValueError):
+        utils.validate_coordinates(lng=lng, lat=lat)
+
+
+@pytest.mark.unit
+@given(lng=_VALID_LNG, lat=_OUT_OF_RANGE_LAT)
+def test_validate_coordinates_rejects_out_of_range_lat(lng, lat):
+    """Finite latitude outside [-90, 90] raises ValueError."""
+    with pytest.raises(ValueError):
+        utils.validate_coordinates(lng=lng, lat=lat)
+
+
+@pytest.mark.unit
+@given(pair=_NAN_PAIR)
+def test_validate_coordinates_rejects_nan(pair):
+    """NaN in either coordinate raises ValueError."""
+    lng, lat = pair
+    with pytest.raises(ValueError):
+        utils.validate_coordinates(lng=lng, lat=lat)
+
+
+@pytest.mark.unit
+@given(pair=_INF_PAIR)
+def test_validate_coordinates_rejects_inf(pair):
+    """Infinity in either coordinate raises ValueError."""
+    lng, lat = pair
+    with pytest.raises(ValueError):
+        utils.validate_coordinates(lng=lng, lat=lat)
+
+
+@pytest.mark.unit
+@given(lat=st.one_of(_OUT_OF_RANGE_LAT, _NAN, _INF))
+def test_validate_lat_rejects_invalid(lat):
+    """validate_lat rejects out-of-range, NaN, and infinity latitude."""
+    with pytest.raises(ValueError):
+        utils.validate_lat(lat=lat)
+
+
+@pytest.mark.unit
+@given(lng=st.one_of(_OUT_OF_RANGE_LNG, _NAN, _INF))
+def test_validate_lng_rejects_invalid(lng):
+    """validate_lng rejects out-of-range, NaN, and infinity longitude."""
+    with pytest.raises(ValueError):
+        utils.validate_lng(lng=lng)


### PR DESCRIPTION
Closes #143

## Summary

Adds property-based tests with [`hypothesis`](https://hypothesis.readthedocs.io/) for `validate_coordinates`, `validate_lat`, and `validate_lng`, complementing the existing example-based `@pytest.mark.parametrize` tests in `tests/utils_test.py`.

The property tests explore the full finite input space:
- valid in-range coordinates pass through unchanged as floats
- out-of-range longitude/latitude raise `ValueError`
- `NaN` and infinity values raise `ValueError`
- `validate_lat` / `validate_lng` independently reject invalid input

This follows the snippet and baseline pattern suggested in the issue (https://github.com/jannikmi/multivar_horner/blob/master/tests/hypothesis_tests.py).

## Changes

- add `hypothesis>=6` to the `test` dependency group in `pyproject.toml`
- add `tests/test_property_validation.py` (7 property tests, all marked `@pytest.mark.unit`)
- add a changelog entry under the unreleased `Internal:` section

No source code under `timezonefinder/` is modified — this is a test-only change.

## Verification

- `uv run pytest tests/test_property_validation.py -v` → 7 passed
- `uv run pytest -m "not integration and not slow" -q` → 760 passed, no regressions
- `make hook` (all 22 pre-commit hooks: ruff, ruff-format, mypy, validate-pyproject, check-manifest, rstcheck, ...) → all passed

The new tests are pure-function (no dataset loading), fast (~0.9s total), and deterministic under the CI profile.

## Notes on the strategies

The `st.floats` strategies explicitly set `allow_nan=False, allow_infinity=False` for the "valid" and "out-of-range" cases so that hypothesis does not emit `NaN`/`Inf` where they are not expected. `NaN` and `Inf` are exercised via dedicated strategies with the appropriate flags. Boundary values (`±180` longitude, `±90` latitude) are inclusive and treated as valid, matching the `<=` comparisons in `is_valid_lat` / `is_valid_lng`.