### PR TITLE
Make the data update script CI-ready (issue #167, PR 1/3)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -16,7 +16,7 @@ This Python library `timezonefinder` provides offline timezone lookups for WGS84
 
 - `timezonefinder/`: Core library with `TimezoneFinder` (full polygon search), `TimezoneFinderL` (shortcut-only heuristic), global helper functions, CLI entry point, and utilities
 - `timezonefinder/data/`: Packaged binary assets (FlatBuffers, NumPy arrays, zone names, shortcut index) consumed at runtime
-- `scripts/`: Tooling for regenerating data (`file_converter.py`, `parse_data.sh`), reporting, and helper configs
+- `scripts/`: Tooling for regenerating data (`file_converter.py`, `update_data.sh`), reporting, and helper configs
 - `tests/`: PyTest suite with unit tests and integration tests
 - `docs/`: Sphinx documentation; `docs/data_format.rst` is authoritative reference for binary layouts
 
@@ -95,7 +95,7 @@ Ocean zones (`Etc/GMT+/-XX`) guarantee a timezone match for all possible input c
 
 ## Data Pipeline
 
-- `parse_data.sh` downloads timezone-boundary-builder release, unpacks to `tmp/`, executes `scripts/file_converter.py` to emit FlatBuffers/NumPy assets
+- `update_data.sh` downloads timezone-boundary-builder release, unpacks to `tmp/`, executes `scripts/file_converter.py` to emit FlatBuffers/NumPy assets
 - The converter multiplies coordinates by 10^7, persists bboxes, hole registries, shortcut maps, and zone metadata
 - Adjust `scripts/configs.py` when experimenting with alternative resolutions or debugging flags
 - When changing the datatype of shortcut-related FlatBuffers schemas (e.g. `hybrid_shortcuts_uint16.fbs`), delete any previously generated `.fbs` binary artifacts so they are regenerated consistently

--- a/.github/workflows/check_data_updates.yml
+++ b/.github/workflows/check_data_updates.yml
@@ -53,7 +53,7 @@ jobs:
           body=$(cat <<EOF
           A new timezone-boundary-builder release [\`$latest\`](https://github.com/evansiroky/timezone-boundary-builder/releases/tag/$latest) is available. The currently packaged data version is \`$current\`.
 
-          To update, regenerate the data with \`parse_data.sh\` (see the release process notes in \`Agents.md\`).
+          To update, regenerate the data with \`update_data.sh\` (see the release process notes in \`Agents.md\`).
 
           Created by workflow run [#${GITHUB_RUN_ID}]($RUN_URL).
           EOF

--- a/Agents.md
+++ b/Agents.md
@@ -8,7 +8,7 @@ This Python library `timezonefinder` provides offline timezone lookups for WGS84
 
 - `timezonefinder/`: core library with `TimezoneFinder` (full polygon search), `TimezoneFinderL` (shortcut-only heuristic), global helper functions, CLI entry point, and utilities for polygon math and binary IO.
 - `timezonefinder/data/`: packaged binary assets (FlatBuffers coordinate stores, NumPy metadata arrays, zone name list, shortcut index) consumed at runtime.
-- `scripts/`: tooling for regenerating data (`file_converter.py`, `parse_data.sh`), reporting, and helper configs shared by tests; relies on `uv` for builds.
+- `scripts/`: tooling for regenerating data (`file_converter.py`, `update_data.sh`), reporting, and helper configs shared by tests; relies on `uv` for builds.
 - `tests/`: PyTest suite with fast unit coverage plus integration tests that build wheels/sdists inside venvs to validate packaging.
 - `docs/`: Sphinx documentation mirroring PyPI content; `docs/data_format.rst` is the authoritative reference for binary layouts.
 - `Makefile`, `tox.ini`, `pyproject.toml`: developer entry points for dependency sync, lint/test orchestration, and distribution metadata.
@@ -20,7 +20,7 @@ The primary lookup flow converts query coordinates to scaled int32 values, colle
 
 ## Data Pipeline
 
-`parse_data.sh` downloads a chosen timezone-boundary-builder release (full or "now", optional ocean polygons), unpacks it to `tmp/`, executes `scripts/file_converter.py` to emit FlatBuffers/NumPy assets under `timezonefinder/data/`, runs `tox`, records the downloaded release tag in the `DATA_VERSION` file (checked weekly against upstream by `.github/workflows/check_data_updates.yml`), bumps the project version with `uv run --bump minor`, and offers to clean intermediates. The converter multiplies coordinates by 10^7, persists bboxes, hole registries, shortcut maps, and zone metadata; adjust `scripts/configs.py` when experimenting with alternative resolutions or debugging flags. When changing the datatype of shortcut-related FlatBuffers schemas (for example `hybrid_shortcuts_uint16.fbs`), delete any previously generated `.fbs` binary artifacts so they are regenerated consistently.
+`update_data.sh` downloads a chosen timezone-boundary-builder release (`--dataset=full|same-since-now`, optional `--with-oceans`), unpacks it to `tmp/`, executes `scripts/file_converter.py` to emit FlatBuffers/NumPy assets under `timezonefinder/data/`, runs `tox`, records the downloaded release tag in the `DATA_VERSION` file (checked weekly against upstream by `.github/workflows/check_data_updates.yml`), bumps the patch version, prepends the matching `CHANGELOG.rst` entry, and deletes intermediates when `--rm-tmp` is passed. The script is non-interactive and safe to run in CI. The converter multiplies coordinates by 10^7, persists bboxes, hole registries, shortcut maps, and zone metadata; adjust `scripts/configs.py` when experimenting with alternative resolutions or debugging flags. When changing the datatype of shortcut-related FlatBuffers schemas (for example `hybrid_shortcuts_uint16.fbs`), delete any previously generated `.fbs` binary artifacts so they are regenerated consistently.
 
 ## Development Workflow
 
@@ -49,7 +49,7 @@ Regenerating data changes the binary blobs in `timezonefinder/data/` and typical
 - the optional Numba dependency accelerates `utils.pt_in_poly_python`; when absent, the CFFI-backed clang extension is used - verify both paths if you touch `utils.py` or polygon math.
 - Keep coordinate scaling factors (`DECIMAL_PLACES_SHIFT`, `COORD2INT_FACTOR`) in sync between runtime and converter; altering them invalidates shipped binaries.
 - `TimezoneFinderL` is heuristic only; prefer full `TimezoneFinder` when correctness matters, and document any behavior changes in `docs/2_use_cases.rst`.
-- The default dataset is the full original dataset. The reduced "now" dataset is available via parse_data.sh for users who prefer a smaller memory footprint, but it loses location-specific names.
+- The default dataset is the full original dataset. The reduced "now" dataset is available via update_data.sh for users who prefer a smaller memory footprint, but it loses location-specific names.
 - Global state in `timezonefinder/global_functions.py` intentionally delays instantiation; avoid side effects before the first call and prefer dependency injection inside tests.
 - Thread-safety: Global helper functions are not thread-safe - prefer explicit `TimezoneFinder(in_memory=True)` instances for concurrent workloads.
 - do not remove the __all__ definitions in `__init__.py` files; they define the public API surface and are checked by tests.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,9 @@ X.X.X (unreleased)
 
 Internal:
 
-* added ``DATA_VERSION`` file tracking which timezone-boundary-builder release the packaged data was generated from, written automatically by ``parse_data.sh`` after a successful parse. Thanks to `Lucas Hemkemeier <https://github.com/hemkdev>`__ for the PR #429
+* added ``DATA_VERSION`` file tracking which timezone-boundary-builder release the packaged data was generated from, written automatically by the data update script after a successful parse. Thanks to `Lucas Hemkemeier <https://github.com/hemkdev>`__ for the PR #429
 * added scheduled GitHub Actions workflow comparing ``DATA_VERSION`` against the latest timezone-boundary-builder release weekly and opening an issue when new boundary data is available (solves issue #273)
+* made the data update script CI-ready and renamed it from ``parse_data.sh`` to ``update_data.sh``: interactive prompts replaced by command line flags (``--dataset=full|same-since-now``, ``--with-oceans``, ``--rm-tmp``) and the changelog entry for data updates is now generated automatically (issue #167)
 
 
 8.2.5 (2026-07-11)

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,7 @@ outdated:
 
 data:
 	rm -rf tmp
-	# choices:
-	# 1) Original full dataset
-	# 1) timezone data with oceans
-	# 0) keep tmp files
-	printf '1\n1\n0\n' | bash parse_data.sh
+	bash update_data.sh --dataset=full --with-oceans
 
 parse:
 	uv run python ./scripts/file_converter.py -inp ./tmp/combined-with-oceans.json

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ It is recommended to install it together with the optional `Numba <https://numba
 
 
 
-**Note:** This library uses the full original timezone dataset with all >440 timezone names, providing full localization capabilities and historical timezone accuracy. For applications that prefer a smaller memory footprint, the reduced "timezones-now" dataset is available via the ``parse_data.sh`` script (cf. `Documentation <https://timezonefinder.readthedocs.io/en/latest/data_format.html#alternative-dataset-options>`__).
+**Note:** This library uses the full original timezone dataset with all >440 timezone names, providing full localization capabilities and historical timezone accuracy. For applications that prefer a smaller memory footprint, the reduced "timezones-now" dataset is available via the ``update_data.sh`` script (cf. `Documentation <https://timezonefinder.readthedocs.io/en/latest/data_format.html#alternative-dataset-options>`__).
 
 
 **Alternative:** Need maximum speed at the cost of accuracy? Check out `tzfpy <https://github.com/ringsaturn/tzfpy>`__ - a fast and lightweight alternative based on Rust.

--- a/docs/2_use_cases.rst
+++ b/docs/2_use_cases.rst
@@ -79,15 +79,17 @@ How to use the ``timezonefinder`` package with data files from another location 
 
 
 
-Data parsing shell script
-*************************
+Data update shell script
+************************
 
-The included ``parse_data.sh`` shell script simplifies downloading the latest version of
+The included ``update_data.sh`` shell script simplifies downloading the latest version of
 `timezone-boundary-builder <https://github.com/evansiroky/timezone-boundary-builder/releases>`__
 data and parsing in with ``file_converter.py``.
-It supports downloading and parsing the ``timezone-boundary-builder`` version WITHOUT ocean timezones.
-This is useful if you do not require ocean timezones and want to have smaller data files.
+It is non-interactive and controlled entirely via command line flags:
 
 ::
 
-    /bin/bash  /path/to/timezonefinder/parse_data.sh
+    /bin/bash /path/to/timezonefinder/update_data.sh [--dataset=full|same-since-now] [--with-oceans] [--rm-tmp]
+
+Without the ``--with-oceans`` flag the dataset WITHOUT ocean timezones is used.
+This is useful if you do not require ocean timezones and want to have smaller data files.

--- a/docs/data_format.rst
+++ b/docs/data_format.rst
@@ -39,18 +39,18 @@ The processing pipeline for this data involves:
 3. Running the ``file_converter.py`` script to compile the data into the binary format used by ``timezonefinder``
 
 
-The script ``parse_data.sh`` automates this process.
+The script ``update_data.sh`` automates this process.
 
 Alternative Dataset Options
 ============================
 
-The ``parse_data.sh`` script also supports downloading the reduced ``timezones-now`` dataset, which merges timezones with identical behavior (as of now) into a single zone. This reduces the number of timezones from ~440 to ~90 and provides a smaller memory footprint. However, this dataset:
+The ``update_data.sh`` script also supports downloading the reduced ``timezones-now`` dataset (via ``--dataset=same-since-now``), which merges timezones with identical behavior (as of now) into a single zone. This reduces the number of timezones from ~440 to ~90 and provides a smaller memory footprint. However, this dataset:
 
 * Provides incorrect data for observed timekeeping methods in the past at certain locations
 * Loses location-specific information (e.g., ``Europe/Berlin`` becomes ``Europe/Paris``)
 * Reduces localization capabilities
 
-If your use case requires the reduced dataset, you can use the ``parse_data.sh`` script to download and process the ``timezones-with-oceans-now.geojson`` file.
+If your use case requires the reduced dataset, you can use the ``update_data.sh`` script to download and process the ``timezones-with-oceans-now.geojson`` file.
 
 
 

--- a/tests/test_data_version.py
+++ b/tests/test_data_version.py
@@ -1,7 +1,7 @@
 """Tests for the DATA_VERSION file tracking the packaged boundary data release.
 
 The file is read by .github/workflows/check_data_updates.yml to detect new
-timezone-boundary-builder releases and written by parse_data.sh on data updates.
+timezone-boundary-builder releases and written by update_data.sh on data updates.
 """
 
 import re

--- a/tests/test_package_contents.py
+++ b/tests/test_package_contents.py
@@ -62,7 +62,7 @@ UNWANTED_DIST_PATTERNS = {
     "CONTRIBUTING.*",
     "Agents.*",
     "Makefile",
-    "parse_data.sh",
+    "update_data.sh",
     "readthedocs.yaml",
     "test_musllinux_wheel.sh",
     "tox.ini",

--- a/update_data.sh
+++ b/update_data.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Download the latest timezone-boundary-builder release, regenerate the packaged
+# binary data, run the tests and prepare a release (version bump + changelog entry).
+# Non-interactive: all behavior is controlled via command line flags (CI-ready).
+set -euo pipefail
 
 WORKING_FOLDER_NAME=tmp
 ARCHIVE_NAME=data_downloaded.zip
@@ -9,8 +13,46 @@ JSON_PREFIX=combined
 JSON_SUFFIX=.json
 URL_PREFIX=https://github.com/evansiroky/timezone-boundary-builder/releases/latest/download/timezones
 URL_SUFFIX=.geojson.zip
+CHANGELOG_PATH=CHANGELOG.rst
+DATA_REPO_URL=https://github.com/evansiroky/timezone-boundary-builder
 
-echo "TIME ZONE DATA PARSING SCRIPT"
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --dataset=full             use the original full dataset (default)
+  --dataset=same-since-now   use the reduced "timezones-now" dataset, merging
+                             timezones with identical behavior from now on
+  --with-oceans              include ocean timezones (Etc/GMT+-XX)
+  --rm-tmp                   delete the temporary data folder ($WORKING_FOLDER_NAME) at the end
+  -h, --help                 show this help message and exit
+EOF
+}
+
+DATASET_SUFFIX=""
+INTERFIX=""
+RM_TMP=0
+
+for arg in "$@"; do
+    case $arg in
+    --dataset=full) DATASET_SUFFIX="" ;;
+    --dataset=same-since-now) DATASET_SUFFIX=-now ;;
+    --with-oceans) INTERFIX=-with-oceans ;;
+    --rm-tmp) RM_TMP=1 ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "ERROR: unknown option '$arg'" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+done
+
+echo "TIME ZONE DATA UPDATE SCRIPT"
 
 # make script work independent of where you invoke it from
 parent_path=$(
@@ -20,24 +62,6 @@ parent_path=$(
 cd "$parent_path" || exit 1
 mkdir -p "$WORKING_FOLDER_NAME" # if does not exist
 
-echo "Which dataset version to download?"
-echo "1) Original full dataset"
-echo "2) Reduced timezones-now dataset"
-read -r DATASET_CHOICE
-
-if [ "$DATASET_CHOICE" -eq 2 ]; then
-    DATASET_SUFFIX=-now
-else
-    DATASET_SUFFIX=""
-fi
-
-echo "use timezone data with oceans (0: No, 1: Yes)? "
-read -r WITH_OCEANS
-if [ "$WITH_OCEANS" -eq 1 ]; then
-    INTERFIX=-with-oceans
-else
-    INTERFIX=""
-fi
 JSON_FILE_NAME=$JSON_PREFIX$INTERFIX$DATASET_SUFFIX$JSON_SUFFIX
 JSON_PATH=./$WORKING_FOLDER_NAME/$JSON_FILE_NAME
 
@@ -88,20 +112,27 @@ else
     echo "WARNING: downloaded release tag unknown, DATA_VERSION not updated"
 fi
 
-# patch version bump
+# patch version bump (data-only releases are patch releases)
 uv version --bump patch
+NEW_VERSION=$(uv version --short)
 
-# TODO
- read -r -p "should all temporary data files be deleted (0: No, 1: Yes)?" do_deletion
- if [ "$do_deletion" -eq 1 ]; then
+# prepend a changelog entry for the data update
+DATA_TAG=$(cat DATA_VERSION)
+ENTRY_TITLE="$NEW_VERSION ($(date +%Y-%m-%d))"
+ENTRY_UNDERLINE=$(printf '%*s' "${#ENTRY_TITLE}" '' | tr ' ' '-')
+{
+    # keep the changelog header (first 3 lines), insert the new entry below it
+    head -n 3 "$CHANGELOG_PATH"
+    printf '\n\n%s\n%s\n\n' "$ENTRY_TITLE" "$ENTRY_UNDERLINE"
+    printf '* updated the data to `%s <%s/releases/tag/%s>`__\n' "$DATA_TAG" "$DATA_REPO_URL" "$DATA_TAG"
+    tail -n +4 "$CHANGELOG_PATH"
+} >"$CHANGELOG_PATH.new"
+mv "$CHANGELOG_PATH.new" "$CHANGELOG_PATH"
+echo "added $CHANGELOG_PATH entry: $ENTRY_TITLE"
+
+if [ "$RM_TMP" -eq 1 ]; then
+    echo "deleting temporary data files..."
     rm -r "$WORKING_FOLDER_NAME"
 fi
 
-# TODO add changelog entry: keep title, current date, parse data version
-# $(uv version) (2022-12-06)
-#------------------
-#
-#* updated the data to `2022g <https://github.com/evansiroky/timezone-boundary-builder/releases/tag/2022g>`__.
-#echo -e "DATA-Line-1\n$(cat input)" > input
-
-echo "SUCCESS! the new package version $(uv version) can now be released!"
+echo "SUCCESS! the new package version $NEW_VERSION can now be released!"


### PR DESCRIPTION
First of the three PRs discussed in #167.

As proposed, this makes the data update script runnable unattended (no interactive prompts), as preparation for the automated update workflow (PR 2).

**Changes:**
- Renamed `parse_data.sh` to **`update_data.sh`** — it does more than parsing (download, parse, test, version bump, changelog), so the new name reflects the full job. Open to other suggestions.
- Replaced the interactive `read` prompts with the self-explanatory flags suggested in the issue: `--dataset=full|same-since-now` (default: `full`), `--with-oceans`, `--rm-tmp`. Unknown flags fail with a usage message.
- The changelog entry for a data update is now generated automatically (resolves the TODO in the script): the version is bumped (patch, as agreed) and an entry matching the existing data-release format is prepended to `CHANGELOG.rst`.
- Added `set -euo pipefail` so any failing step aborts the run.
- Updated all references to the old script name (Makefile, docs, README, `Agents.md`, `check_data_updates.yml`, tests). `make data` now runs `bash update_data.sh --dataset=full --with-oceans`, same behavior as before.

**Tested:** full dry-run with stubbed `wget`/`curl`/`unzip`/`uv` (download URL built correctly for all 4 dataset/ocean combinations, `DATA_VERSION` updated, changelog entry rendered correctly, `--rm-tmp` cleanup), plus the pre-commit hooks and test suite.