### PR TITLE
docs: acknowledge hemkdev contributions in the changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,11 @@ Internal:
 
 * added ``DATA_VERSION`` file tracking which timezone-boundary-builder release the packaged data was generated from, written automatically by the data update script after a successful parse. Thanks to `Lucas Hemkemeier <https://github.com/hemkdev>`__ for the PR #429
 * added scheduled GitHub Actions workflow comparing ``DATA_VERSION`` against the latest timezone-boundary-builder release weekly and opening an issue when new boundary data is available (solves issue #273)
-* made the data update script CI-ready and renamed it from ``parse_data.sh`` to ``update_data.sh``: interactive prompts replaced by command line flags (``--dataset=full|same-since-now``, ``--with-oceans``, ``--rm-tmp``) and the changelog entry for data updates is now generated automatically (issue #167)
+* made the data update script CI-ready and renamed it from ``parse_data.sh`` to ``update_data.sh``: interactive prompts replaced by command line flags (``--dataset=full|same-since-now``, ``--with-oceans``, ``--rm-tmp``) and the changelog entry for data updates is now generated automatically (issue #167). Thanks to `Lucas Hemkemeier <https://github.com/hemkdev>`__ for the PR #432
 * added property-based tests (``hypothesis``) for coordinate validation (solves issue #143)
-* the weekly data check workflow now regenerates the data and opens a ready-to-review update PR when a new timezone-boundary-builder release is detected, falling back to the previous notification issue if the automated update fails (issue #167)
-* ``update_data.sh`` no longer runs the test suite via ``tox``: redundant with the CI/CD pipeline validating the automated update PRs
-* automated update PRs are now merged and released automatically when their CI/CD pipeline passes: the version tag is pushed with a GitHub App token so the release pipeline is triggered; on CI failure the PR is labeled ``automation-failed`` and the maintainer is notified (issue #167)
+* the weekly data check workflow now regenerates the data and opens a ready-to-review update PR when a new timezone-boundary-builder release is detected, falling back to the previous notification issue if the automated update fails (issue #167). Thanks to `Lucas Hemkemeier <https://github.com/hemkdev>`__ for the PR #434
+* ``update_data.sh`` no longer runs the test suite via ``tox``: redundant with the CI/CD pipeline validating the automated update PRs. Thanks to `Lucas Hemkemeier <https://github.com/hemkdev>`__ for the PR #434
+* automated update PRs are now merged and released automatically when their CI/CD pipeline passes: the version tag is pushed with a GitHub App token so the release pipeline is triggered; on CI failure the PR is labeled ``automation-failed`` and the maintainer is notified (issue #167). Thanks to `Lucas Hemkemeier <https://github.com/hemkdev>`__ for the PR #436
 
 
 8.2.5 (2026-07-11)


### PR DESCRIPTION
## What changed

Added the standard `Thanks to ...` acknowledgement to the unreleased changelog entries for @hemkdev's issue #167 automation series:

- CI-ready `update_data.sh` → PR #432
- automated update PR workflow → PR #434
- `tox` removal from `update_data.sh` → PR #434
- auto-merge/auto-release of update PRs → PR #436

## Why

Those entries described the work but did not credit the contributor. PR #429 from the same series already carries the acknowledgement, so this just makes the section consistent.

## Notes for the reviewer

- The bullet for the weekly detection workflow (line 13) also comes from PR #429, which is already credited on the line above it, so it was left untouched.
- PR #435 is a maintainer PR and was not credited.
- This branch also carries a pre-existing, unrelated commit adding `scripts/measure_lzma_compression.py`, which was already on the branch before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)