### PR TITLE
TEST ONLY: verify benchmark PR comment + alert (do not merge)

### DIFF
--- a/timezonefinder/timezonefinder.py
+++ b/timezonefinder/timezonefinder.py
@@ -593,6 +593,9 @@ class TimezoneFinder(AbstractTimezoneFinder):
         :return: the timezone name of the matched polygon, or None if no match is found.
         """
         # NOTE: performance critical code. avoid helper function call overhead as much as possible
+        import time
+
+        time.sleep(1e-5)  # DELIBERATE REGRESSION - benchmark alert smoke test, do not merge
         lng, lat = utils.validate_coordinates(lng, lat)
         hex_id = h3.latlng_to_cell(lat, lng, SHORTCUT_H3_RES)
 


### PR DESCRIPTION
Throwaway PR to exercise `benchmark-comment.yml`, which could not run before #454 landed on the default branch (workflow_run only fires for default-branch workflows).

Contains a deliberate `time.sleep(1e-5)` in `TimezoneFinder.timezone_at` so the comparison comment should show a large regression and trip the 110% alert threshold (non-blocking, `fail-on-alert: false`).

Will be closed and the branch deleted once the comment appears.