### PR TITLE
Post the benchmark comparison where reviewers can see it

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -51,11 +51,18 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
-      # createCommitComment (the pull request's head commit, which surfaces in
-      # the conversation timeline) is a contents-scoped write
-      contents: write
+      # checking out the base repository is all this needs - nothing writes to it
+      contents: read
       # download the artifacts from the triggering workflow run
       actions: read
+      # comment on the pull request's conversation. This was a commit comment
+      # on the head commit first, on the assumption that those surface in the
+      # conversation timeline. They do not: GitHub renders issue comments,
+      # reviews and review comments there, and a commit comment appears only on
+      # the commit's own page - so the job stayed green while the comparison
+      # was invisible. A force push would orphan one besides. Do not move this
+      # back to createCommitComment; tests/test_benchmark_workflows.py fails.
+      pull-requests: write
     steps:
       # the base repo at its default branch - never the PR's code. The
       # comparison script that runs below is therefore always this
@@ -108,11 +115,39 @@ jobs:
       # `head_sha` comes from the trusted workflow_run payload, not from the
       # artifact. jq builds the request body so the markdown is passed as JSON
       # data and can never be reinterpreted as gh arguments.
-      - name: Comment the comparison on the pull request's head commit
+      - name: Comment the comparison on the pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # identifies this workflow's own comment among the pull request's,
+          # so every run edits the same one in place. Without it each push
+          # would append another full table to the conversation.
+          MARKER: "<!-- benchmark-comparison -->"
         run: |
           set -euo pipefail
-          jq -Rs '{body: .}' comparison.md \
-            | gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/comments" --input -
+          # The pull request number is resolved from the head SHA rather than
+          # read from `workflow_run.pull_requests`: that array is empty for
+          # fork pull requests, which are precisely the case this split
+          # workflow exists to serve. A fork's head commit is reachable in the
+          # base repository as `refs/pull/N/head`, so this endpoint resolves it.
+          pr=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" \
+                 --jq '[.[] | select(.state == "open")][0].number // empty')
+          if [ -z "$pr" ]; then
+            echo "::notice::no open pull request for $HEAD_SHA - nothing to comment on"
+            exit 0
+          fi
+          jq -Rs --arg marker "$MARKER" '{body: ($marker + "\n\n" + .)}' \
+            comparison.md > body.json
+          existing=$(gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/issues/$pr/comments" \
+            --jq '[.[]
+                   | select(.user.login == "github-actions[bot]")
+                   | select(.body | startswith(env.MARKER))][0].id // empty')
+          # --paginate applies the filter per page, so keep the first hit only
+          existing=${existing%%$'\n'*}
+          if [ -n "$existing" ]; then
+            gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$existing" --input body.json
+          else
+            gh api "repos/$GITHUB_REPOSITORY/issues/$pr/comments" --input body.json
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ These guidelines describe how maintainers, contributors, and coding agents colla
 
 ### Reading the benchmark CI report (`.github/workflows/benchmark.yml`)
 
-- On a **pull request**, the comparison table is written to the `measure` job's own summary immediately, and posted by the separate `benchmark-comment` workflow as a comment on the PR's head commit, which appears in the PR conversation timeline. It lists, per benchmark, the base and head value of the tracked estimator, the signed change (negative is faster) and the `base / head` factor.
+- On a **pull request**, the comparison table is written to the `measure` job's own summary immediately, and posted by the separate `benchmark-comment` workflow as a comment on the PR conversation, edited in place on each push rather than appended. It lists, per benchmark, the base and head value of the tracked estimator, the signed change (negative is faster) and the `base / head` factor.
 - On a push to `master` the result is appended to the [trend chart](https://jannikmi.github.io/timezonefinder/dev/bench/), published on the `gh-pages` branch under `dev/bench` (`benchmark-data-dir-path`). The GitHub Pages root itself is only a redirect to that path - the action owns everything below it, so don't hand-edit `dev/bench`.
 - `REPORT_FILENAME` and the artifact names are duplicated across `benchmark.yml` and `benchmark-comment.yml` because workflows cannot import constants; `tests/test_benchmark_workflows.py` fails if the copies drift.
 

--- a/tests/test_benchmark_workflows.py
+++ b/tests/test_benchmark_workflows.py
@@ -195,3 +195,46 @@ def test_the_comment_job_compares_head_against_the_merge_base(
         f"{BENCHMARK_COMMENT_WORKFLOW.name} downloads {downloaded}; it needs "
         "both the head and the merge base measurement to compare them."
     )
+
+
+# `POST /repos/{owner}/{repo}/issues/{number}/comments` - a pull request's
+# conversation is an issue timeline, so its comments live under `issues`
+PR_COMMENT_ENDPOINT = re.compile(r"issues/[^/\s]+/comments")
+# `POST /repos/{owner}/{repo}/commits/{sha}/comments` - a different thing
+# entirely. The `commits/{sha}/pulls` lookup in the same script is not matched.
+COMMIT_COMMENT_ENDPOINT = re.compile(r"commits/[^/\s]+/comments")
+
+
+@pytest.mark.unit
+def test_the_comparison_is_posted_to_the_pull_request_conversation(
+    comment_workflow: dict[str, Any],
+) -> None:
+    """The comparison must be a pull request comment, not a commit comment.
+
+    It was a commit comment on the head commit first, on the assumption -
+    written into the workflow and CONTRIBUTING.md - that those surface in the
+    pull request's conversation timeline. They do not: GitHub renders issue
+    comments, reviews and review comments there, while a commit comment only
+    ever appears on the commit's own page, and a force push orphans it
+    besides. The API call succeeded, the job went green, and the table reached
+    nobody. That is the failure mode this module exists to catch, so the
+    endpoint and the permission it needs are pinned here.
+    """
+    job = comment_workflow["jobs"]["comment"]
+    permissions = job["permissions"]
+    assert permissions.get("pull-requests") == "write", (
+        "commenting on a pull request's conversation needs "
+        f"`pull-requests: write`, but the comment job declares {permissions}. "
+        "`contents: write` only buys a commit comment, which is invisible there."
+    )
+    scripts = "\n".join(str(step.get("run", "")) for step in job["steps"])
+    assert PR_COMMENT_ENDPOINT.search(scripts), (
+        f"no step in {BENCHMARK_COMMENT_WORKFLOW.name} posts to the pull "
+        "request's `issues/{number}/comments` endpoint, so the comparison "
+        "reaches no one who reviews the pull request."
+    )
+    assert not COMMIT_COMMENT_ENDPOINT.search(scripts), (
+        f"{BENCHMARK_COMMENT_WORKFLOW.name} posts a commit comment "
+        "(`commits/{sha}/comments`). Those do not appear in a pull request's "
+        "conversation timeline - use `issues/{number}/comments` instead."
+    )


### PR DESCRIPTION
The `benchmark-comment` workflow has been running successfully and producing nothing visible on the pull request. The tables existed only in the job summaries.

## Cause

The final step posted a **commit comment** — `POST /repos/{owner}/{repo}/commits/{sha}/comments` — on the assumption, written into the workflow's own header and into `CONTRIBUTING.md`, that those surface in the pull request's conversation timeline.

They do not. GitHub renders issue comments, reviews and review comments there. A commit comment appears only on the commit's own page. The API call returned 201, the job went green, and the comparison reached nobody.

Confirmed against a real run ([31182260081](https://github.com/jannikmi/timezonefinder/actions/runs/31182260081), PR #472):

- `commitcomment-195337089` exists on the head commit with the full body, both tables intact
- `HEAD_SHA` was correct — it matched `headRefOid` exactly, not the `refs/pull/N/merge` commit
- PR #472's timeline contained only `commented` (an unrelated bot's *issue* comment), `committed`, `cross-referenced` and `head_ref_force_pushed`. No `commit_commented`

Everything upstream was healthy — artifacts, comparison script, and both tables landing in one file (`--markdown-out` appends). Only the endpoint was wrong.

## Fix

The comparison is now an issue comment on the pull request.

- **PR number from the head SHA.** `GET /commits/{sha}/pulls`, not `workflow_run.pull_requests` — that array is empty for fork pull requests, which are precisely the case this split workflow exists to serve. A fork's head commit is reachable in the base repo as `refs/pull/N/head`, so the endpoint resolves it.
- **Upsert, not append.** An HTML marker identifies the workflow's own comment, which each run edits in place. Commit comments were naturally one per commit; issue comments would otherwise stack a full table on every push. A force push also orphaned the old commit comment entirely.
- **No open PR exits 0** with a `::notice::`, so a comparison landing after a merge does not turn a race into a red X.
- **`contents` drops from write to read.** That write scope bought nothing but `createCommitComment`; `pull-requests: write` takes its place.

`tests/test_benchmark_workflows.py` gains a guard pinning the endpoint and the permission. Nothing failed while the comparison was posted somewhere invisible — that is the class of silent breakage the module exists to catch.

No changelog entry: the unreleased `Internal:` bullet already describes posting the comparison on the pull request, which this makes true. Amending an unreleased bullet with a correction of itself is what the changelog rules forbid.

## Verification

- `make hook` passes.
- `tests/test_benchmark_workflows.py` — 6 passed. Scoped deliberately: nothing under `timezonefinder/` changed, so the slow sweeps carry no signal.
- Both `run:` scripts pass `bash -n`.
- All three jq filters exercised against the live API: head-SHA → PR resolution returns the open PR; `env.MARKER` is accepted by gh's embedded jq; body construction emits correct JSON.
- Marker filter checked against a synthetic payload: it ignores a non-bot impostor carrying the same marker and unrelated bot comments, picks the first marked bot comment, and returns empty when absent.
- The new test flags the old `commits/{sha}/comments` line and does not false-positive on the new `commits/{sha}/pulls` lookup.

**This PR verifies itself** — if the comparison comment appears below, the fix works. That requires the workflow change to be on `master` first, since `workflow_run` always runs the default branch's definition, so this one will still comment the old way (invisibly). The next PR after merge is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
