### PR TITLE
publish timezonefinder to PyPI by Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,8 +310,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release]
     if: startsWith(github.ref, 'refs/tags/')
+    # the environment the trusted publisher on PyPI is bound to; a run outside it gets
+    # no OIDC identity PyPI will accept
+    environment: pypi
     permissions:
-        id-token: write
+      # required for Trusted Publishing: the job exchanges this for a short-lived
+      # PyPI token, which is why no secret appears anywhere below
+      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7
@@ -333,8 +338,8 @@ jobs:
         uses: actions/download-artifact@v8
 
       # the data wheel is deliberately left out of dist/: this job uploads whatever
-      # is in it with the `timezonefinder` token, and publishing timezonefinder-data
-      # is publish_data.yml's, on its own tag and its own credentials
+      # is in it as `timezonefinder`, and publishing timezonefinder-data is
+      # publish_data.yml's, on its own tag and its own trusted publisher
       - name: Copy artifacts to dist/ folder
         run: |
           find . -name 'artifact-*' -exec unzip '{}' \;
@@ -348,5 +353,4 @@ jobs:
       - name: PyPI Publishing
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_DEPLOYMENT_API_KEY }}
           skip-existing: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,12 @@ name: build
 # deliberately creates no GitHub Release, so this can only fire for a data tag if
 # someone publishes one by hand. That is why the `release` job carries the ref guard as
 # well; `publish-pypi` needs it, so skipping it skips the upload too.
+#
+# The name of this file is load-bearing: the trusted publisher on PyPI for
+# `timezonefinder` names it, alongside this repository and the `pypi` deployment
+# environment. Renaming it breaks publishing silently - PyPI simply refuses the OIDC
+# identity, at tag-push time, when the release is already half out. A rename means
+# updating the publisher on pypi.org in the same breath.
 on:
   pull_request:
   push:
@@ -262,17 +268,6 @@ jobs:
           find . -name '*.tar.gz' -exec mv '{}' dist/ \;
           find . -name '*.whl' -exec mv '{}' dist/ \;
           ls -lR dist/
-
-      # TODO re-enable Test PyPI publishing. disabled due to project size limits
-      # -   name: Test PyPI Publishing
-      #     # NOTE: PRs from forks fail due to: "missing or insufficient OIDC token permissions,
-      #     #  the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable was unset"
-      #     # -> test publishing cannot be triggered in PRs?!
-      #     uses: pypa/gh-action-pypi-publish@release/v1
-      #     with:
-      #         password: ${{ secrets.TEST_PYPI_DEPLOYMENT_API_KEY }}
-      #         repository-url: https://test.pypi.org/legacy/
-      #         skip-existing: true
 
       # The two distributions release independently, and on a data format change the
       # order is fixed: data first, then the code requiring it. Backwards, the wheel is

--- a/.github/workflows/publish_data.yml
+++ b/.github/workflows/publish_data.yml
@@ -20,6 +20,12 @@ name: publish data
 # credential exists to leak or rotate. It also removes the bootstrap problem a token
 # would have had - a project-scoped token cannot be minted for a project that does not
 # exist yet, whereas a *pending publisher* covers the very first upload.
+#
+# The name of this file is therefore load-bearing: the publisher names it, alongside
+# this repository and the `pypi-data` deployment environment. Renaming it breaks
+# publishing silently - PyPI simply refuses the OIDC identity, at tag-push time, when
+# the release is already half out. A rename means updating the publisher on pypi.org in
+# the same breath.
 
 on:
   push:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Changelog
 X.X.X (unreleased)
 ------------------
 
+Internal:
+
+* ``timezonefinder`` is now published to PyPI by Trusted Publishing (OIDC) rather than with a long-lived API token, matching how ``timezonefinder-data`` already publishes. The upload job runs in the ``pypi`` deployment environment and exchanges its OIDC identity for a short-lived, project-scoped upload token, so no publishing credential exists in repository secrets to leak or rotate, and each stream's identity is bound to an environment the other does not use. This requires a trusted publisher configured for the ``timezonefinder`` project on PyPI; without it the release upload fails.
+
 
 8.3.0 (2026-08-19)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ X.X.X (unreleased)
 
 Internal:
 
-* ``timezonefinder`` is now published to PyPI by Trusted Publishing (OIDC) rather than with a long-lived API token, matching how ``timezonefinder-data`` already publishes. The upload job runs in the ``pypi`` deployment environment and exchanges its OIDC identity for a short-lived, project-scoped upload token, so no publishing credential exists in repository secrets to leak or rotate, and each stream's identity is bound to an environment the other does not use. This requires a trusted publisher configured for the ``timezonefinder`` project on PyPI; without it the release upload fails. Solves issue #525
+* ``timezonefinder`` is now published to PyPI by Trusted Publishing (OIDC) rather than with a long-lived API token, matching how ``timezonefinder-data`` already publishes. The upload job runs in the ``pypi`` deployment environment and exchanges its OIDC identity for a short-lived, project-scoped upload token, so no publishing credential exists in repository secrets to leak or rotate, and each stream's identity is bound to an environment the other does not use. This requires a trusted publisher configured for the ``timezonefinder`` project on PyPI; without it the release upload fails - and since a publisher names the workflow *file*, each of the two workflows now records that renaming it breaks publishing. The commented-out Test PyPI step, disabled since the project outgrew the index's size limit and holding the last reference to a third token, is gone. Solves issue #525
 
 
 8.3.0 (2026-08-19)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ X.X.X (unreleased)
 
 Internal:
 
-* ``timezonefinder`` is now published to PyPI by Trusted Publishing (OIDC) rather than with a long-lived API token, matching how ``timezonefinder-data`` already publishes. The upload job runs in the ``pypi`` deployment environment and exchanges its OIDC identity for a short-lived, project-scoped upload token, so no publishing credential exists in repository secrets to leak or rotate, and each stream's identity is bound to an environment the other does not use. This requires a trusted publisher configured for the ``timezonefinder`` project on PyPI; without it the release upload fails.
+* ``timezonefinder`` is now published to PyPI by Trusted Publishing (OIDC) rather than with a long-lived API token, matching how ``timezonefinder-data`` already publishes. The upload job runs in the ``pypi`` deployment environment and exchanges its OIDC identity for a short-lived, project-scoped upload token, so no publishing credential exists in repository secrets to leak or rotate, and each stream's identity is bound to an environment the other does not use. This requires a trusted publisher configured for the ``timezonefinder`` project on PyPI; without it the release upload fails. Solves issue #525
 
 
 8.3.0 (2026-08-19)

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -273,10 +273,10 @@ the data. Now it releases a distribution containing no code, so the question doe
 
 The two namespaces share a branch, so what keeps them apart is enforced rather than conventional:
 ``build.yml`` excludes ``data-v*`` at its trigger, and again on the job that creates the GitHub
-Release, because the ``release: types: [published]`` trigger consults no tag filter. The data
-stream publishes by PyPI Trusted Publishing rather than with a token: PyPI trusts that one workflow
-file, gated on its own deployment environment, so it holds no credential that could upload
-``timezonefinder`` and none that could leak. The tag is pushed with a GitHub App token because
+Release, because the ``release: types: [published]`` trigger consults no tag filter. Both
+streams publish by PyPI Trusted Publishing rather than with a token: PyPI trusts one workflow file
+per project, each gated on its own deployment environment, so neither holds a credential that could
+upload the other's distribution and neither holds one that could leak. The tag is pushed with a GitHub App token because
 a tag pushed with the default ``GITHUB_TOKEN`` does not trigger downstream workflows - the release
 would be tagged and never built. The run reads ``master`` before the merge and checks the squash
 commit's first parent against it afterwards, so a push that landed in between withholds the tag

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -12,7 +12,8 @@ reached by a data tag, and that the two streams cannot borrow each other's
 credentials - both of which fail invisibly: a data tag that reaches build.yml's
 release job produces a GitHub Release for the code version with code artefacts
 attached to it, and nothing about that looks wrong until someone reads the release
-page.
+page. Neither stream holds a token any more, so what keeps them apart is the
+deployment environment each publishing identity is bound to.
 """
 
 import pytest
@@ -207,45 +208,51 @@ def test_the_data_stream_creates_no_github_release() -> None:
 
 
 @pytest.mark.unit
-def test_the_data_stream_publishes_without_a_shared_credential() -> None:
-    """What scopes the data stream to its own project, now that it holds no token.
+def test_both_streams_publish_without_a_shared_credential() -> None:
+    """What scopes each stream to its own project, now that neither holds a token.
 
-    It publishes by Trusted Publishing: PyPI trusts this workflow file, gated on a
-    deployment environment, and the job exchanges an OIDC identity for a short-lived
-    upload token. Two things therefore have to hold, and neither is self-announcing if
-    it stops holding. The job must request ``id-token: write`` - without it the
-    exchange has nothing to present, and the upload fails only at release time, on a
-    tag that cannot be pushed twice. And it must not reach for the code stream's
-    token, which would let a data release upload ``timezonefinder``.
+    Both publish by Trusted Publishing: PyPI trusts one workflow file per project,
+    gated on a deployment environment, and the job exchanges an OIDC identity for a
+    short-lived upload token. Three things therefore have to hold, and none is
+    self-announcing if it stops holding. A publishing job must request
+    ``id-token: write`` - without it the exchange has nothing to present, and the
+    upload fails only at release time, on a tag that cannot be pushed twice. It must
+    be gated on a deployment environment, which is what the publisher on PyPI is bound
+    to. And the two streams must not name the *same* environment, which is what keeps
+    a data release from presenting an identity PyPI accepts for ``timezonefinder``.
     """
-    workflow = _workflow(PUBLISH_DATA_WORKFLOW)
-    publishing = _jobs_using(workflow, PYPI_PUBLISH_ACTION)
-    assert publishing, f"{PUBLISH_DATA_WORKFLOW.name} publishes nothing"
+    publishing = {
+        (path.name, name): job
+        for path in (BUILD_WORKFLOW, PUBLISH_DATA_WORKFLOW)
+        for name, job in _jobs_using(_workflow(path), PYPI_PUBLISH_ACTION).items()
+    }
+    assert len(publishing) == 2, (
+        f"expected one PyPI upload job per stream, found {sorted(publishing)} - this "
+        "check no longer covers what it names"
+    )
 
-    for name, job in publishing.items():
+    for (workflow_name, name), job in publishing.items():
         assert job.get("permissions", {}).get("id-token") == "write", (
-            f"{name} publishes by OIDC but does not request id-token: write"
+            f"{workflow_name}: {name} publishes by OIDC but does not request "
+            "id-token: write"
         )
         assert job.get("environment"), (
-            f"{name} is not gated on a deployment environment, which is what the "
-            "trusted publisher on PyPI is bound to"
+            f"{workflow_name}: {name} is not gated on a deployment environment, which "
+            "is what the trusted publisher on PyPI is bound to"
+        )
+        with_a_password = [
+            step
+            for step in job["steps"]
+            if _uses(step).startswith(PYPI_PUBLISH_ACTION)
+            and "password" in (step.get("with") or {})
+        ]
+        assert not with_a_password, (
+            f"{workflow_name}: {name} passes a `password` to {PYPI_PUBLISH_ACTION}, "
+            "so it uploads with a long-lived token rather than by OIDC"
         )
 
-    code_secrets = {
-        step["with"]["password"]
-        for job in _jobs_using(_workflow(BUILD_WORKFLOW), PYPI_PUBLISH_ACTION).values()
-        for step in job["steps"]
-        if _uses(step).startswith(PYPI_PUBLISH_ACTION)
-    }
-    assert code_secrets, (
-        f"no publishing credential found in {BUILD_WORKFLOW.name} - this check is "
-        "vacuous, so the code stream's mechanism has changed too"
-    )
-    data_workflow_text = PUBLISH_DATA_WORKFLOW.read_text(encoding="utf-8")
-    borrowed = sorted(
-        secret for secret in code_secrets if secret.strip() in data_workflow_text
-    )
-    assert not borrowed, (
-        f"{PUBLISH_DATA_WORKFLOW.name} references the code stream's credential "
-        f"{borrowed}; that token can upload `timezonefinder`"
+    environments = {job["environment"] for job in publishing.values()}
+    assert len(environments) == len(publishing), (
+        f"both streams publish from the same deployment environment {environments}; "
+        "a data release could then present an identity PyPI accepts for the code"
     )


### PR DESCRIPTION
Closes #525 — its second and final slice; the `timezonefinder-data` half landed with #446's data split.

## What

`publish-pypi` in `.github/workflows/build.yml` now publishes `timezonefinder` by PyPI Trusted Publishing (OIDC) instead of with the long-lived `PYPI_DEPLOYMENT_API_KEY` secret — the same shape `publish_data.yml` already uses for `timezonefinder-data`:

- the job declares `environment: pypi` (the deployment environment the trusted publisher on PyPI is bound to; the environment already existed in repo settings with `master` / `*.*.*` deployment policies, but no job referenced it)
- the `pypa/gh-action-pypi-publish` step drops its `password:` input; `id-token: write` was already requested and is now what the upload actually uses

## Why

Hardening, not a fix — the API-token path works today. It removes the last long-lived publishing credential from repository secrets: nothing left to leak or rotate, and each stream's upload identity is bound to a deployment environment the other does not use (`pypi` vs `pypi-data`).

## Requires a matching change on PyPI

**Merging this without a trusted publisher configured for the `timezonefinder` project on PyPI breaks publishing** — the next release tag would fail at the upload step, on a tag that cannot be pushed twice. The publisher must name owner `jannikmi`, repository `timezonefinder`, workflow `build.yml`, environment `pypi`. The maintainer has confirmed this configuration exists.

Nothing in CI exercises the upload (it runs on tag pushes only), so the first real proof is the next release.

## Also updated

- `tests/test_release_workflows.py`: the test asserting the data stream does not borrow the code stream's token read `password:` out of build.yml's publish step, which no longer exists. It now covers both streams — each publishing job must request `id-token: write`, be gated on a deployment environment, and pass no `password`, and the two environments must differ.
- `docs/architecture.rst` *How it ships*: the sentence claiming only the data stream publishes by Trusted Publishing.
- `CHANGELOG.rst` under `Internal:`.

## Checks

`uv run pre-commit run --all-files` clean; `uv run pytest tests/test_release_workflows.py` passes (6 tests).

## The rest of #525

The issue's two remaining asks are in this PR, so it closes complete:

- **the commented-out Test PyPI block is deleted.** It has been disabled since the project outgrew test.pypi.org's size limit, and it held the last reference to `TEST_PYPI_DEPLOYMENT_API_KEY` — migrating a step that does not run buys nothing.
- **each workflow header records that its filename is load-bearing.** A trusted publisher pins *(repository, workflow filename, environment)*, so renaming `build.yml` or `publish_data.yml` breaks publishing with no local signal — PyPI refuses the OIDC identity at tag-push time. Nothing in the repository can verify the registration, so a comment at the point of decision is the honest guard; a test would only assert a filename against itself.

Not taken from the issue: it floats scoping the publisher to an environment with *required reviewers*, a manual gate on every release. `pypi` is used here purely as the publisher's binding, with the existing `master` / `*.*.*` deployment policies and no reviewer gate — worth deciding separately, and it would be wrong for the data stream, which releases with no human in the loop by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)