### PR TITLE
Check the data distribution is published before cutting a code release

### DIFF
--- a/contributing/workflows/prepare-and-publish-code-release.md
+++ b/contributing/workflows/prepare-and-publish-code-release.md
@@ -23,6 +23,27 @@ Fetch `origin` and tags, inspect `uv version --short`, the top changelog section
 
 Require a clean/accounted working tree; current `master` equal to `origin/master`; no open release pull request or release branch; a non-empty unreleased section; and a green latest `master` run.
 
+### Publish the data distribution first
+
+**A release whose declared `timezonefinder-data` version PyPI does not serve cannot ship, and the ordering is the first thing to check, not the last.** Read the requirement out of the checkout and ask the index what a user's resolver will ask:
+
+```bash
+grep timezonefinder-data pyproject.toml
+curl -s https://pypi.org/pypi/timezonefinder-data/json | python3 -c 'import json,sys; print(sorted(json.load(sys.stdin)["releases"]))'
+```
+
+If the declared version is absent, the data release goes first — publish the data, then the code requiring it, or `timezonefinder` is uninstallable for everyone between the two. Every format change is in this position by construction, because `DATA_FORMAT_VERSION` is the data distribution's major version and the root pins `<N+1`; the [data pipeline and release order](../development/data-pipeline-format-versioning-and-release-order.md) carries the rest.
+
+The data release is a `data-v<version>` tag on `master`, published by `publish_data.yml` from the wheel `DATA_BUILD_RUN` names. Before tagging, confirm that run succeeded and that its `artifact-data-wheel` has not expired — the run id is the only reference to it, and an expired artefact is re-made by re-dispatching `compile_data.yml` on the branch and recording the new id:
+
+```bash
+gh api repos/<owner>/<repo>/actions/runs/"$(cat DATA_BUILD_RUN)"/artifacts -q '.artifacts[] | "\(.name) expired=\(.expired)"'
+```
+
+This tag publishes to PyPI irreversibly and is bound by the same rule as the code tag: **ask for authorization naming the version in the same session**, and never push it on standing instruction alone. `scripts/check_data_dependency.py` refuses the *code* publish while the data is missing, so a forgotten data release is caught rather than shipped — but it is caught at the tag, after the release pull request has been reviewed and merged, which is the wrong end of the process to discover it. Do not write a changelog bullet claiming the data "is published before this release" until it is.
+
+## Rewrite the changelog
+
 Rewrite the entire unreleased section to describe the release end state: merge bullets for one feature, remove tuning history and review narration, retain decision-relevant trade-offs, and keep internal work under `Internal:`. Compare every commit since the newest tag with the section and add missing non-exempt changes without inventing behavior. Show the resulting changelog diff before selecting the version level so the evidence and the decision are reviewed together.
 
 Compute patch, minor, and major candidates with `uv version --bump <level> --dry-run`. Select the strongest applicable rule:
@@ -51,13 +72,25 @@ Establish the machine is quiet enough to measure on **before** measuring, since 
 uv run python -m scripts.assert_acceleration_path --expect "$(make -s print-benchmark-acceleration-path)"
 ```
 
-`benchmark-noise` runs `benchmarks-ci`, which uses this checkout's environment rather than `make benchmarks`' isolated one, and `timezonefinder/utils.py` binds the point-in-polygon backend at import time, preferring numba whenever it is importable. A development environment synced with `--all-groups` therefore has numba, so the noise floor would characterise a different implementation than the pages assert. A failing assertion means the gate cannot be read here: say so, and treat the reports as stale rather than committing against a threshold measured on the wrong kernel.
+`benchmark-noise` runs `benchmarks-ci`, which uses this checkout's environment rather than `make benchmarks`' isolated one, and `timezonefinder/utils.py` binds the point-in-polygon backend at import time, preferring numba whenever it is importable. A development environment synced with `--all-groups` therefore has numba, so `make benchmark-noise` would characterise a different implementation than the pages assert, and the assertion above fails in exactly that environment.
 
-On a passing assertion, measure the floor:
+That failure is about the *environment the gate runs in*, not about the machine, so it is not on its own a reason to declare the reports stale. `make reports` is unaffected — `benchmarks`, `latency` and `memory` all measure under `BENCHMARK_ENV` and assert the path themselves. Read the floor under that same environment instead of `make benchmark-noise`, so the gate describes the kernel the pages do:
 
 ```bash
-make benchmark-noise
+uv run --isolated --group test --group compare python -m scripts.assert_acceleration_path \
+  --expect "$(make -s print-benchmark-acceleration-path)"
+for i in 1 2 3 4 5; do
+  uv run --isolated --group test --group compare pytest benchmarks -m benchmark_core \
+    --benchmark-min-rounds=50 --benchmark-json=tmp/benchmark-core-raw.json
+  uv run --isolated --group test --group compare python -m scripts.normalize_benchmark_json \
+    --benchmark-json=tmp/benchmark-core-raw.json \
+    --output=tmp/benchmark-noise/run-$i.json --estimator=min
+done
+uv run --isolated --group test --group compare python -m scripts.benchmark_noise \
+  tmp/benchmark-noise/run-*.json --estimator=min --min-runs=5
 ```
+
+Treat the reports as stale only when the floor itself cannot be brought under threshold. Where the environment resolves the asserted path directly, `make benchmark-noise` is the shorter route to the same number.
 
 It repeats the CI core subset five times on unchanged code and prints the observed spread against a threshold derived from it. Over threshold means the machine is too busy — other agent sessions, a build, a sync — and the run must not be committed. Do not treat waiting for an idle machine as a plan: this checkout is worked concurrently, so re-check rather than assume quiet arrives, and if it does not, stop and report the reports as stale rather than committing numbers the threshold rejects.
 

--- a/contributing/workflows/prepare-and-publish-code-release.md
+++ b/contributing/workflows/prepare-and-publish-code-release.md
@@ -29,8 +29,12 @@ Require a clean/accounted working tree; current `master` equal to `origin/master
 
 ```bash
 grep timezonefinder-data pyproject.toml
-curl -s https://pypi.org/pypi/timezonefinder-data/json | python3 -c 'import json,sys; print(sorted(json.load(sys.stdin)["releases"]))'
+uv run python -c 'from scripts.check_data_dependency import fetch_pypi_payload, released_versions
+from scripts.configs import DATA_DISTRIBUTION_NAME
+print([str(v) for v in released_versions(fetch_pypi_payload(DATA_DISTRIBUTION_NAME))])'
 ```
+
+Ask through `released_versions`, not through the raw `releases` map the index serves: a release whose files are all yanked, or which has no files at all, is listed there but cannot satisfy a range requirement. Reusing the guard's own predicate is what keeps this precheck and the tag-time guard from disagreeing — a hand-rolled listing that counts those as published would reintroduce here exactly the gap this check exists to close.
 
 If the declared version is absent, the data release goes first — publish the data, then the code requiring it, or `timezonefinder` is uninstallable for everyone between the two. Every format change is in this position by construction, because `DATA_FORMAT_VERSION` is the data distribution's major version and the root pins `<N+1`; the [data pipeline and release order](../development/data-pipeline-format-versioning-and-release-order.md) carries the rest.
 
@@ -77,6 +81,8 @@ uv run python -m scripts.assert_acceleration_path --expect "$(make -s print-benc
 That failure is about the *environment the gate runs in*, not about the machine, so it is not on its own a reason to declare the reports stale. `make reports` is unaffected — `benchmarks`, `latency` and `memory` all measure under `BENCHMARK_ENV` and assert the path themselves. Read the floor under that same environment instead of `make benchmark-noise`, so the gate describes the kernel the pages do:
 
 ```bash
+set -e
+rm -rf tmp/benchmark-noise && mkdir -p tmp/benchmark-noise
 uv run --isolated --group test --group compare python -m scripts.assert_acceleration_path \
   --expect "$(make -s print-benchmark-acceleration-path)"
 for i in 1 2 3 4 5; do
@@ -89,6 +95,8 @@ done
 uv run --isolated --group test --group compare python -m scripts.benchmark_noise \
   tmp/benchmark-noise/run-*.json --estimator=min --min-runs=5
 ```
+
+Both opening lines carry the gate's weight, which is why `make benchmark-noise` has their equivalents. Without `set -e` a failed `pytest` iteration leaves the previous iteration's `benchmark-core-raw.json` in place, and the normalize step happily writes it again under the next run number — five files, one of them a duplicate, and a floor that is narrow because a measurement failed rather than because the machine is quiet. Without the `rm -rf`, a `run-6.json` left by an earlier invocation joins the glob, mixing runs of different code into a gate that assumes the code did not change.
 
 Treat the reports as stale only when the floor itself cannot be brought under threshold. Where the environment resolves the asserted path directly, `make benchmark-noise` is the shorter route to the same number.
 


### PR DESCRIPTION
Found while cutting 9.0.0 ([#586](https://github.com/jannikmi/timezonefinder/pull/586)).

## The gap

The prepare half's preconditions never asked whether PyPI actually serves the `timezonefinder-data` version the release declares. Cutting 9.0.0 walked straight past it: the changelog asserted the data "is published before this release" while PyPI held only `1.2026.3` and `2.2026.3` against a declared `timezonefinder-data>=3.2026.3,<4`.

`scripts/check_data_dependency.py` does catch this — nothing would have shipped broken. But it catches it at the tag, after the release pull request has been reviewed and merged, which is the wrong end of the process to discover that a second, ordered release has to happen first. Every format change is in this position by construction, since `DATA_FORMAT_VERSION` is the data distribution's major version and the root pins `<N+1`.

The precondition now sits with the other prepare preconditions, with:

- the two commands that answer it (the declared requirement, and what the index serves)
- the `artifact-data-wheel` liveness check the `data-v*` tag depends on, since the `DATA_BUILD_RUN` id is the only reference to it
- the same authorization rule the code tag carries — the data tag publishes to PyPI irreversibly too, and must not be pushed on standing instruction alone
- a note not to write the "published before this release" bullet until it is true

## Also: the noise-gate guidance was wrong

It told a reader whose environment fails the acceleration assertion to treat the reports as stale. But that failure is about *the environment the gate runs in*, not about the machine: `make benchmark-noise` runs `benchmarks-ci`, which is the one measurement target without `BENCHMARK_ENV`, while `make reports` measures under it and asserts the path itself. The floor is readable under that same isolated environment, which is how 9.0.0's reports were in the end measured and committed (worst spread 101.4% against the 110% threshold, clang path, Apple M1 Pro).

Declaring the pages stale is now reserved for a floor that cannot be brought under threshold, rather than for an environment that happens to have numba installed.

No changelog entry: the contributor-memory layer is exempt under the [changelog policy](contributing/development/changelog-and-release-note-policy.md), `Internal:` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)