### PR TITLE
merge-round: report a merge by its squash commit, not a revert command

### DIFF
--- a/contributing/workflows/review-and-merge-one-pull-request.md
+++ b/contributing/workflows/review-and-merge-one-pull-request.md
@@ -89,7 +89,7 @@ Compare those names with the workflows that trigger on `pull_request` and the `p
 gh pr merge <n> --squash --delete-branch
 ```
 
-An escalated pull request is briefed and merged only on an answer in the same session; use the provider's structured question interface for that one question when it has one, recommendation first. Report every unasked merge with the command that undoes it, so a merge the maintainer disagrees with costs a revert rather than a review.
+An escalated pull request is briefed and merged only on an answer in the same session; use the provider's structured question interface for that one question when it has one, recommendation first. Report every unasked merge by number and squash commit; a merge the maintainer disagrees with is reverted from that, and spelling out the command for a case this rare costs a line in every report to save a lookup in almost none.
 
 After merging, fast-forward local `master`, confirm the head is the squash commit, and re-check every remaining pull request before the next round begins.
 
@@ -103,4 +103,4 @@ The run ends when no open pull request is left, or when every one that remains i
 
 ## Reporting
 
-Per round: the pick and one clause for each pull request that waited; what the update did and which conflicts were resolved how; the gate that ran and its result; merged, briefed, or parked, with the reason; and what changed for the rest of the queue. Close the run with the pull requests merged in order and the command that reverts each, what remains open and what each one waits for, and the pick the next run would start from.
+Per round: the pick and one clause for each pull request that waited; what the update did and which conflicts were resolved how; the gate that ran and its result; merged, briefed, or parked, with the reason; and what changed for the rest of the queue. Close the run with the pull requests merged in order, each with its squash commit, what remains open and what each one waits for, and the pick the next run would start from.


### PR DESCRIPTION
## What changed

The merge-round workflow required every round to print the revert command beside each merge, in two places:

- the **Merge** section: *"Report every unasked merge with the command that undoes it"*
- the **Reporting** section: *"the pull requests merged in order and the command that reverts each"*

Both now ask for the squash commit instead. The command is fixed and the sha is already in the report, so a maintainer who wants to revert can fetch it on demand — and reverting a merge is rare enough that printing the command in every round costs a line in almost every report to save a lookup in almost none.

## What deliberately stays

The **Reversibility** bullet in the briefing section:

> What reverting the squash commit restores, and what it cannot: anything published, fetched from upstream, or already built on.

That is a judgement about the change — whether a revert is even the whole undo — not a command to paste, and it is the half that decides whether a pull request escalates under trigger 2.

## Verification

`tests/test_contributor_memory.py` and `tests/test_improvement_ledger.py` — 11 passed. `uv run pre-commit run --all-files` clean.

No changelog entry: contributor memory and the agent-facing workflow layer take none, per the core contract.

Raised by the maintainer while running the workflow, whose reports carried the command five times in one run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)