### PR TITLE
Fix skipped PyPI upload after tag release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -407,7 +407,15 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [release]
-    if: startsWith(github.ref, 'refs/tags/')
+    # `release` overrides the implicit success() because its own `test` dependency is
+    # intentionally skipped on tags. That skipped ancestor still propagates through
+    # the dependency chain: without a status function here GitHub skips this job even
+    # after `release` succeeds, leaving a green run with nothing on PyPI. Re-check the
+    # direct dependency explicitly after dropping that implicit gate.
+    if: >
+      !cancelled() &&
+      startsWith(github.ref, 'refs/tags/') &&
+      needs.release.result == 'success'
     # the environment the trusted publisher on PyPI is bound to; a run outside it gets
     # no OIDC identity PyPI will accept
     environment: pypi

--- a/changelog.d/internal/prevent-skipped-pypi-upload.rst
+++ b/changelog.d/internal/prevent-skipped-pypi-upload.rst
@@ -1,0 +1,1 @@
+Prevent code-release workflows from silently skipping the PyPI upload after their tag-side test job is intentionally skipped.

--- a/contributing/development/pull-request-and-ci-workflow.md
+++ b/contributing/development/pull-request-and-ci-workflow.md
@@ -23,3 +23,11 @@ Wait for the base to land and cut from `master`. When that is genuinely impracti
 If it happens anyway, do not reopen the closed pull request: the squash means the base's commits never become ancestors of `master`, so retargeting it there shows the base's work as a second, duplicated diff. Rebase onto `master` instead - `git rebase --onto origin/master <base-branch-tip> HEAD`, passing `HEAD` so the rebase lands detached and the pushed branch is never rewritten - and open a fresh pull request from a new branch that references the closed one.
 
 Thank you for helping to keep timezonefinder robust and high-performance!
+
+## Skipped job propagation
+
+When a job deliberately skips a dependency, every publishing job downstream of that skip must name a status function, then explicitly require each direct dependency that must succeed.
+
+A successful intermediate job does not absorb a skipped ancestor: GitHub otherwise skips the later upload before allocating a runner, while the workflow remains green.
+
+Pin this behavior in workflow-structure tests because pull-request runs cannot exercise tag-only publication.

--- a/contributing/workflows/prepare-and-publish-code-release.md
+++ b/contributing/workflows/prepare-and-publish-code-release.md
@@ -126,3 +126,10 @@ print([str(v) for v in released_versions(fetch_pypi_payload("timezonefinder"))])
 Report the tag, the workflow URL and that answer; never "published" on a green run alone.
 
 A skipped or failed upload is recovered by fixing the cause and re-running that job, never by retagging — the tag and the GitHub Release already exist, and pushing it again publishes nothing. A run that failed for want of the matching green `master` run is the same shape: wait, then rerun. Any failure after a successful upload requires a new release.
+
+When a tag-side job deliberately skips a dependency, every publishing job downstream
+of that skip must name a status function and then explicitly require each direct
+dependency that must succeed. A successful intermediate job does not absorb a skipped
+ancestor: GitHub otherwise skips the later upload before allocating a runner, while
+the workflow itself remains green. Pin this behavior in the workflow-structure tests;
+it is invisible on pull requests and first executes after the version tag is spent.

--- a/contributing/workflows/prepare-and-publish-code-release.md
+++ b/contributing/workflows/prepare-and-publish-code-release.md
@@ -126,10 +126,3 @@ print([str(v) for v in released_versions(fetch_pypi_payload("timezonefinder"))])
 Report the tag, the workflow URL and that answer; never "published" on a green run alone.
 
 A skipped or failed upload is recovered by fixing the cause and re-running that job, never by retagging — the tag and the GitHub Release already exist, and pushing it again publishes nothing. A run that failed for want of the matching green `master` run is the same shape: wait, then rerun. Any failure after a successful upload requires a new release.
-
-When a tag-side job deliberately skips a dependency, every publishing job downstream
-of that skip must name a status function and then explicitly require each direct
-dependency that must succeed. A successful intermediate job does not absorb a skipped
-ancestor: GitHub otherwise skips the later upload before allocating a runner, while
-the workflow itself remains green. Pin this behavior in the workflow-structure tests;
-it is invisible on pull requests and first executes after the version tag is spent.

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -524,6 +524,29 @@ def test_a_version_tag_publishes_without_re_running_the_matrix() -> None:
 
 
 @pytest.mark.unit
+def test_the_upload_overrides_a_skipped_transitive_dependency() -> None:
+    """A successful direct dependency does not erase its skipped ancestor.
+
+    ``release`` needs the deliberately skipped tag-side ``test`` job and uses a status
+    function to run anyway. GitHub propagates that skipped ancestor to the upload too,
+    even though the upload directly needs only the successful ``release`` job. The
+    upload therefore needs its own status function and must explicitly require its
+    direct dependency to have succeeded; omitting either half produces a green workflow
+    with a skipped upload or publishes after a failed release.
+    """
+    job = _workflow(BUILD_WORKFLOW)["jobs"]["publish-pypi"]
+    condition = str(job.get("if", ""))
+    assert any(function in condition for function in _STATUS_FUNCTIONS), (
+        "`publish-pypi` inherits `release`'s skipped `test` ancestor unless its "
+        "condition names a status function"
+    )
+    assert "needs.release.result == 'success'" in condition, (
+        "a status function removes the implicit success gate, so `publish-pypi` must "
+        "explicitly require its direct `release` dependency to have succeeded"
+    )
+
+
+@pytest.mark.unit
 def test_a_tag_release_still_requires_every_job_that_did_run() -> None:
     """Naming a status function drops the implicit `success()` over *all* of `needs`.
 


### PR DESCRIPTION
## Summary

- override GitHub Actions skipped-ancestor propagation in the PyPI upload job
- require the successful release dependency explicitly after enabling the status-function override
- pin the release invariant in tests and contributor memory

## Verification

- `uv run pytest tests/test_release_workflows.py -q` (19 passed)
- `make hook`

## Release recovery

After this merges, the existing `9.0.0` tag and GitHub Release must be reused. Do not retag. Trigger the corrected workflow against that release ref and verify the `Publish to PyPI` job itself succeeds plus PyPI serves 9.0.0.