### PR TITLE
Add recovery path for skipped PyPI releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish_existing_tag:
+        description: Existing code-release tag whose attached artifacts PyPI still lacks
+        required: false
+        type: string
 
 env:
   # Use one base Python version with future-proof abi3 support
@@ -414,8 +419,17 @@ jobs:
     # direct dependency explicitly after dropping that implicit gate.
     if: >
       !cancelled() &&
-      startsWith(github.ref, 'refs/tags/') &&
-      needs.release.result == 'success'
+      (
+        (
+          startsWith(github.ref, 'refs/tags/') &&
+          needs.release.result == 'success'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/master' &&
+          inputs.publish_existing_tag != ''
+        )
+      )
     # the environment the trusted publisher on PyPI is bound to; a run outside it gets
     # no OIDC identity PyPI will accept
     environment: pypi
@@ -435,11 +449,58 @@ jobs:
       # from the workspace, and the staging action below has to be on disk
       - name: Checkout repo
         uses: actions/checkout@v7
+        with:
+          # A recovery dispatch executes the corrected workflow from master but must
+          # inspect and publish the immutable tree named by the existing release tag.
+          ref: ${{ inputs.publish_existing_tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Install uv for recovery guards
+        if: inputs.publish_existing_tag != ''
+        uses: astral-sh/setup-uv@v7
+
+      - name: Verify the recovery tag's required data version is published
+        if: inputs.publish_existing_tag != ''
+        run: uv run --with packaging python -m scripts.check_data_dependency
+
+      - name: Verify the recovery tag consumed every changelog fragment
+        if: inputs.publish_existing_tag != ''
+        run: uv run python -m scripts.changelog_fragments --check --require-consumed
+
+      - name: Validate and download the existing release artifacts
+        if: inputs.publish_existing_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.publish_existing_tag }}
+        run: |
+          if [[ ! "${RELEASE_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.](post|dev)[0-9]+)?$ ]]; then
+            echo "Recovery tag is not a code-release version: ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor HEAD origin/master; then
+            echo "Recovery tag ${RELEASE_TAG} is not on master." >&2
+            exit 1
+          fi
+          release_tag=$(gh release view "${RELEASE_TAG}" --json tagName,isDraft \
+            --jq 'select(.isDraft == false) | .tagName')
+          if [[ "${release_tag}" != "${RELEASE_TAG}" ]]; then
+            echo "No published GitHub Release exists for ${RELEASE_TAG}." >&2
+            exit 1
+          fi
+          mkdir -p dist
+          gh release download "${RELEASE_TAG}" \
+            --pattern "timezonefinder-${RELEASE_TAG}-*.whl" \
+            --pattern "timezonefinder-${RELEASE_TAG}.tar.gz" \
+            --dir dist
+          test "$(( $(find dist -maxdepth 1 -name '*.whl' | wc -l) ))" -gt 0
+          test "$(( $(find dist -maxdepth 1 -name '*.tar.gz' | wc -l) ))" -eq 1
+          test "$(( $(find dist -maxdepth 1 -name 'timezonefinder_data-*' | wc -l) ))" -eq 0
 
       # the data wheel is deliberately left out of dist/: this job uploads whatever
       # is in it as `timezonefinder`, and publishing timezonefinder-data is
       # publish_data.yml's, on its own tag and its own trusted publisher
       - name: Stage artifacts in dist/
+        if: inputs.publish_existing_tag == ''
         uses: ./.github/actions/stage-artifacts
         with:
           include-data-wheel: "false"

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@
 #   builsdist  - build a single source distribution tarball
 #   build      - build wheels for supported Python versions
 #   release    - tag the current commit with the version number and push it
+#   release-recover - dispatch trusted publishing for an existing code-release tag
+#                     whose GitHub assets exist but whose PyPI upload did not run
 #   rmtag      - remove the current version tag locally and remotely
 #   changelog  - preview the unreleased changelog section assembled from changelog.d/
 #   changelog-assemble - fold changelog.d/ into CHANGELOG.rst and consume the fragments
@@ -464,6 +466,14 @@ release:
 	@echo "pushing the tag to the remote repository"
 	@git push origin "$(VERSION)"
 
+release-recover:
+	@if [ -z "$(RELEASE_TAG)" ]; then \
+		echo "Error: pass RELEASE_TAG=<existing-version-tag>"; \
+		exit 1; \
+	fi
+	@echo "dispatching trusted-publisher recovery for existing tag $(RELEASE_TAG)"
+	@gh workflow run build.yml --ref master -f publish_existing_tag="$(RELEASE_TAG)"
+
 rmtag:
 	@echo "removing the tag: $(VERSION)"
 	@git tag -d "$(VERSION)"
@@ -481,3 +491,5 @@ docs:
 	print-benchmark-acceleration-path latency \
 	memory memory-ci memory-noise print-ci-memory-json print-memory-chart-json print-timing-chart-json \
 	changelog changelog-assemble acceleration-paths
+
+.PHONY: release release-recover

--- a/changelog.d/internal/recover-existing-code-release.rst
+++ b/changelog.d/internal/recover-existing-code-release.rst
@@ -1,0 +1,1 @@
+Add a guarded trusted-publishing recovery command for an existing code tag whose GitHub Release assets were not uploaded to PyPI.

--- a/contributing/development/pull-request-and-ci-workflow.md
+++ b/contributing/development/pull-request-and-ci-workflow.md
@@ -31,3 +31,9 @@ When a job deliberately skips a dependency, every publishing job downstream of t
 A successful intermediate job does not absorb a skipped ancestor: GitHub otherwise skips the later upload before allocating a runner, while the workflow remains green.
 
 Pin this behavior in workflow-structure tests because pull-request runs cannot exercise tag-only publication.
+
+GitHub loads a tag-triggered workflow from the tagged commit, so merging a workflow fix does not change retries for an existing tag.
+
+When a code tag and GitHub Release exist but PyPI lacks the version, use `make release-recover RELEASE_TAG=<version>` from current `master`.
+
+That dispatch runs the corrected trusted-publisher workflow from `master`, checks out the immutable tag for its release guards, and uploads only that release's attached code artifacts; never move or recreate the tag.

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -434,7 +434,9 @@ def _as_python(condition: str) -> str:
     expression = re.sub(r"needs\.([A-Za-z0-9_-]+)\.result", r"needs['\1']", expression)
     expression = expression.replace("cancelled()", "cancelled")
     expression = expression.replace("always()", "True")
+    expression = expression.replace("github.event_name", "event_name")
     expression = expression.replace("github.ref", "ref")
+    expression = re.sub(r"inputs\.([A-Za-z0-9_]+)", r"inputs.get('\1', '')", expression)
     expression = re.sub(
         r"startsWith\(\s*([^,]+?)\s*,\s*('[^']*')\s*\)",
         r"\1.startswith(\2)",
@@ -445,7 +447,14 @@ def _as_python(condition: str) -> str:
     return expression.replace("\0NE\0", "!=")
 
 
-def _simulate(workflow: dict, ref: str, failing: frozenset[str] = frozenset()) -> dict:
+def _simulate(
+    workflow: dict,
+    ref: str,
+    failing: frozenset[str] = frozenset(),
+    *,
+    event_name: str = "push",
+    inputs: dict[str, str] | None = None,
+) -> dict:
     """Every job's result for a run on ``ref``, with ``failing`` jobs failing.
 
     Models the two rules that make this workflow's conditions non-obvious: a job with no
@@ -468,7 +477,13 @@ def _simulate(workflow: dict, ref: str, failing: frozenset[str] = frozenset()) -
             value = eval(  # noqa: S307 - the input is this repository's own workflow
                 _as_python(condition),
                 {},
-                {"ref": ref, "needs": needs, "cancelled": False},
+                {
+                    "ref": ref,
+                    "needs": needs,
+                    "cancelled": False,
+                    "event_name": event_name,
+                    "inputs": inputs or {},
+                },
             )
             names_status_function = any(fn in condition for fn in _STATUS_FUNCTIONS)
             runs = bool(value) and (names_status_function or all_needs_succeeded)
@@ -520,6 +535,33 @@ def test_a_version_tag_publishes_without_re_running_the_matrix() -> None:
         assert results[name] == "success", (
             f"`{name}` is skipped on a version tag: a skipped `needs` job skips its "
             "dependents, so the condition has to name a status check function"
+        )
+
+
+@pytest.mark.unit
+def test_an_existing_release_can_be_recovered_only_from_master_dispatch() -> None:
+    """Recovery uses the corrected default-branch workflow without moving the tag."""
+    workflow = _workflow(BUILD_WORKFLOW)
+    recovery_inputs = {"publish_existing_tag": "9.0.0"}
+
+    recovered = _simulate(
+        workflow,
+        "refs/heads/master",
+        event_name="workflow_dispatch",
+        inputs=recovery_inputs,
+    )
+    assert recovered["release"] == "skipped"
+    assert recovered["publish-pypi"] == "success"
+
+    for ref, event_name in (
+        ("refs/heads/topic", "workflow_dispatch"),
+        ("refs/heads/master", "push"),
+    ):
+        results = _simulate(
+            workflow, ref, event_name=event_name, inputs=recovery_inputs
+        )
+        assert results["publish-pypi"] == "skipped", (
+            f"existing-release recovery publishes for {event_name=} on {ref=}"
         )
 
 


### PR DESCRIPTION
## Summary

- add a master-only workflow dispatch that recovers an existing code release through the configured PyPI trusted publisher
- check out the immutable tag, rerun release guards, and download only that GitHub Release’s code artifacts
- add `make release-recover RELEASE_TAG=<version>` and durable contributor guidance

## Safety

The recovery path never creates, moves, or deletes a tag. It requires a published GitHub Release, a version-shaped code tag on master, and excludes timezonefinder-data artifacts.

## Verification

- `uv run pytest tests/test_release_workflows.py tests/test_contributor_memory.py tests/test_changelog_fragments.py -q` (60 passed)
- `make hook`