### PR TITLE
Fix existing-release recovery guard order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -459,10 +459,6 @@ jobs:
         if: inputs.publish_existing_tag != ''
         uses: astral-sh/setup-uv@v7
 
-      - name: Verify the recovery tag's required data version is published
-        if: inputs.publish_existing_tag != ''
-        run: uv run --with packaging python -m scripts.check_data_dependency
-
       - name: Verify the recovery tag consumed every changelog fragment
         if: inputs.publish_existing_tag != ''
         run: uv run python -m scripts.changelog_fragments --check --require-consumed
@@ -495,6 +491,12 @@ jobs:
           test "$(( $(find dist -maxdepth 1 -name '*.whl' | wc -l) ))" -gt 0
           test "$(( $(find dist -maxdepth 1 -name '*.tar.gz' | wc -l) ))" -eq 1
           test "$(( $(find dist -maxdepth 1 -name 'timezonefinder_data-*' | wc -l) ))" -eq 0
+
+      # This guard reads the wheel in dist/, so recovery must download the immutable
+      # release artifacts above before running it.
+      - name: Verify the recovery tag's required data version is published
+        if: inputs.publish_existing_tag != ''
+        run: uv run --with packaging python -m scripts.check_data_dependency
 
       # the data wheel is deliberately left out of dist/: this job uploads whatever
       # is in it as `timezonefinder`, and publishing timezonefinder-data is

--- a/changelog.d/internal/recover-existing-code-release.rst
+++ b/changelog.d/internal/recover-existing-code-release.rst
@@ -1,1 +1,1 @@
-Add a guarded trusted-publishing recovery command for an existing code tag whose GitHub Release assets were not uploaded to PyPI.
+Add a guarded trusted-publishing recovery command that downloads and validates an existing code tag's GitHub Release assets before uploading them to PyPI.

--- a/contributing/development/pull-request-and-ci-workflow.md
+++ b/contributing/development/pull-request-and-ci-workflow.md
@@ -37,3 +37,5 @@ GitHub loads a tag-triggered workflow from the tagged commit, so merging a workf
 When a code tag and GitHub Release exist but PyPI lacks the version, use `make release-recover RELEASE_TAG=<version>` from current `master`.
 
 That dispatch runs the corrected trusted-publisher workflow from `master`, checks out the immutable tag for its release guards, and uploads only that release's attached code artifacts; never move or recreate the tag.
+
+Recovery guards that inspect wheel metadata must run after those attached artifacts are downloaded into `dist/`; checkout alone provides source trees, not the already-published code wheel the recovery promises to upload.

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -566,6 +566,23 @@ def test_an_existing_release_can_be_recovered_only_from_master_dispatch() -> Non
 
 
 @pytest.mark.unit
+def test_recovery_downloads_the_release_wheel_before_inspecting_it() -> None:
+    """The data guard discovers metadata from the staged code wheel in ``dist/``."""
+    steps = _workflow(BUILD_WORKFLOW)["jobs"]["publish-pypi"]["steps"]
+    step_names = [step.get("name") for step in steps]
+    download_index = step_names.index(
+        "Validate and download the existing release artifacts"
+    )
+    data_guard_index = step_names.index(
+        "Verify the recovery tag's required data version is published"
+    )
+    assert download_index < data_guard_index, (
+        "recovery checks the code wheel's data dependency before downloading that "
+        "wheel into dist/"
+    )
+
+
+@pytest.mark.unit
 def test_the_upload_overrides_a_skipped_transitive_dependency() -> None:
     """A successful direct dependency does not erase its skipped ancestor.
 


### PR DESCRIPTION
## Summary

- download the immutable GitHub Release artifacts before inspecting the code wheel's data dependency
- pin the required step ordering in the release-workflow tests
- record the ordering invariant in contributor memory and amend the existing changelog fragment

## Validation

- `uv run pytest tests/test_release_workflows.py -q` (21 passed)
- `make hook`

This fixes the recovery failure in run 34577663780, where the data guard found no `timezonefinder-*.whl` because `dist/` had not been populated yet.
